### PR TITLE
Issue #24 - Reusable Schema Definitions

### DIFF
--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -6,6 +6,8 @@ import contractService from '../services/contract-service'
 import ListingDetail from './listing-detail'
 import Form from 'react-jsonschema-form'
 import Overlay from './overlay'
+import _ from 'lodash'
+import Schemas from '../schemas/index'
 
 class ListingCreate extends Component {
 
@@ -48,14 +50,11 @@ class ListingCreate extends Component {
   }
 
   handleSchemaSelection() {
-    fetch(`/schemas/${this.state.selectedSchemaType}.json`)
-    .then((response) => response.json())
-    .then((schemaJson) => {
-      this.setState({
-        selectedSchema: schemaJson,
-        schemaFetched: true,
-        step: this.STEP.DETAILS
-      })
+    Schemas[this.state.selectedSchemaType].definitions = Schemas.definitions
+    this.setState({
+      selectedSchema: Schemas[this.state.selectedSchemaType],
+      schemaFetched: true,
+      step: this.STEP.DETAILS
     })
   }
 

--- a/src/schemas/announcements.js
+++ b/src/schemas/announcements.js
@@ -1,8 +1,8 @@
-{
+module.exports = {
   "$schema":"http://json-schema.org/draft-04/schema#",
-  "description": "Distributed Getaround",
+  "description":"Distributed Nextdoor",
   "type": "object",
-  "required": ["name","category","description","price"],
+  "required": ["name","category","description"],
   "properties": {
     "name": {
       "type": "string",
@@ -14,28 +14,28 @@
       "type": "string",
       "title": "Category",
       "enum": [
-        "Airplane Charter",
-        "Bike Rentals",
-        "Boat Rentals",
-        "Car Rentals",
-        "Taxi service",
-        "Yacht charters"
+        "Activities",
+        "Artists",
+        "Childcare",
+        "Classes",
+        "General",
+        "Groups",
+        "Local News",
+        "Lost & Found",
+        "Musicians",
+        "Personals",
+        "Pets",
+        "Politics",
+        "Resumes",
+        "Volunteers"
       ],
-      "default":"Car Rentals"
+      "default": "Local News"
     },
     "description": {
       "type": "string",
       "title": "Description",
       "minLength": "10",
       "maxLength": "1024"
-    },
-    "location": {
-      "type": "string",
-      "title": "Location"
-    },
-    "price": {
-      "type": "number",
-      "title": "Price in ETH"
     },
     "pictures": {
       "type": "array",

--- a/src/schemas/definitions.js
+++ b/src/schemas/definitions.js
@@ -1,0 +1,6 @@
+module.exports = {
+  "price": {
+    "type": "number",
+    "title": "Price in ETH"
+  }
+}

--- a/src/schemas/for-sale.js
+++ b/src/schemas/for-sale.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "$schema":"http://json-schema.org/draft-04/schema#",
   "description":"Distributed Craigslist/Ebay/Amazon",
   "type": "object",
@@ -72,8 +72,7 @@
       "title": "Location"
     },
     "price": {
-      "type": "number",
-      "title": "Price in ETH"
+      "$ref": "#/definitions/price"
     },
     "pictures": {
       "type": "array",

--- a/src/schemas/housing.js
+++ b/src/schemas/housing.js
@@ -1,6 +1,6 @@
-{
+module.exports = {
   "$schema":"http://json-schema.org/draft-04/schema#",
-  "description": "Distributed Ticketmaster/Eventbrite",
+  "description": "Distributed Airbnb",
   "type": "object",
   "required": ["name","category","description","price"],
   "properties": {
@@ -14,26 +14,20 @@
       "type": "string",
       "title": "Category",
       "enum": [
-        "Arts",
-        "Classes & Workshops",
-        "Conference",
-        "Fundraisers",
-        "Music",
-        "Non-profit event",
-        "Other",
-        "Sports",
-        "Theater",
-        "Tradeshow"
-      ]
-    },
-    "datetime": {
-        "type": "string",
-        "format": "date-time",
-        "title": "When"
-    },
-    "location": {
-      "type": "string",
-      "title": "Where"
+        "Apts Wanted",
+        "Apts/Housing for Rent",
+        "Housing Swap",
+        "Office & Commercial",
+        "Parking & Storage",
+        "Real Estate",
+        "Real Estate Wanted",
+        "Room/Share Wanted",
+        "Rooms & Shares",
+        "Sublet/Temp Wanted",
+        "Sublets & Temporary",
+        "Vacation Rentals"
+      ],
+      "default":"Vacation Rentals"
     },
     "description": {
       "type": "string",
@@ -41,9 +35,12 @@
       "minLength": "10",
       "maxLength": "1024"
     },
+    "location": {
+      "type": "string",
+      "title": "Location"
+    },
     "price": {
-      "type": "number",
-      "title": "Price in ETH"
+      "$ref": "#/definitions/price"
     },
     "pictures": {
       "type": "array",

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -1,0 +1,17 @@
+import Announcements from './announcements';
+import ForSale from './for-sale';
+import Housing from './housing';
+import Services from './services';
+import Tickets from './tickets';
+import Transportation from './transportation';
+import Defininitions from './definitions';
+
+module.exports = {
+  "announcements": Announcements,
+  "for-sale": ForSale,
+  "housing": Housing,
+  "services": Services,
+  "tickets": Tickets,
+  "transportation": Transportation,
+  "definitions" : Defininitions
+}

--- a/src/schemas/services.js
+++ b/src/schemas/services.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "$schema":"http://json-schema.org/draft-04/schema#",
   "description": "Distributed Elance/99 Designs/Postmates/Fiver/Handy/Thumbtack",
   "type": "object",
@@ -45,8 +45,7 @@
       "title": "Location"
     },
     "price": {
-      "type": "number",
-      "title": "Price in ETH"
+      "$ref": "#/definitions/price"
     },
     "pictures": {
       "type": "array",

--- a/src/schemas/tickets.js
+++ b/src/schemas/tickets.js
@@ -1,6 +1,6 @@
-{
+module.exports = {
   "$schema":"http://json-schema.org/draft-04/schema#",
-  "description": "Distributed Airbnb",
+  "description": "Distributed Ticketmaster/Eventbrite",
   "type": "object",
   "required": ["name","category","description","price"],
   "properties": {
@@ -14,20 +14,26 @@
       "type": "string",
       "title": "Category",
       "enum": [
-        "Apts Wanted",
-        "Apts/Housing for Rent",
-        "Housing Swap",
-        "Office & Commercial",
-        "Parking & Storage",
-        "Real Estate",
-        "Real Estate Wanted",
-        "Room/Share Wanted",
-        "Rooms & Shares",
-        "Sublet/Temp Wanted",
-        "Sublets & Temporary",
-        "Vacation Rentals"
-      ],
-      "default":"Vacation Rentals"
+        "Arts",
+        "Classes & Workshops",
+        "Conference",
+        "Fundraisers",
+        "Music",
+        "Non-profit event",
+        "Other",
+        "Sports",
+        "Theater",
+        "Tradeshow"
+      ]
+    },
+    "datetime": {
+        "type": "string",
+        "format": "date-time",
+        "title": "When"
+    },
+    "location": {
+      "type": "string",
+      "title": "Where"
     },
     "description": {
       "type": "string",
@@ -35,13 +41,8 @@
       "minLength": "10",
       "maxLength": "1024"
     },
-    "location": {
-      "type": "string",
-      "title": "Location"
-    },
     "price": {
-      "type": "number",
-      "title": "Price in ETH"
+      "$ref": "#/definitions/price"
     },
     "pictures": {
       "type": "array",

--- a/src/schemas/transportation.js
+++ b/src/schemas/transportation.js
@@ -1,8 +1,8 @@
-{
+module.exports = {
   "$schema":"http://json-schema.org/draft-04/schema#",
-  "description":"Distributed Nextdoor",
+  "description": "Distributed Getaround",
   "type": "object",
-  "required": ["name","category","description"],
+  "required": ["name","category","description","price"],
   "properties": {
     "name": {
       "type": "string",
@@ -14,28 +14,27 @@
       "type": "string",
       "title": "Category",
       "enum": [
-        "Activities",
-        "Artists",
-        "Childcare",
-        "Classes",
-        "General",
-        "Groups",
-        "Local News",
-        "Lost & Found",
-        "Musicians",
-        "Personals",
-        "Pets",
-        "Politics",
-        "Resumes",
-        "Volunteers"
+        "Airplane Charter",
+        "Bike Rentals",
+        "Boat Rentals",
+        "Car Rentals",
+        "Taxi service",
+        "Yacht charters"
       ],
-      "default": "Local News"
+      "default":"Car Rentals"
     },
     "description": {
       "type": "string",
       "title": "Description",
       "minLength": "10",
       "maxLength": "1024"
+    },
+    "location": {
+      "type": "string",
+      "title": "Location"
+    },
+    "price": {
+      "$ref": "#/definitions/price"
     },
     "pictures": {
       "type": "array",


### PR DESCRIPTION
This is in response to issue #24. 

So I did some research around if Mozilla would add in support for fetching sub schemas by url and discovered that they won't. They mention it very explicitly, but kind of hard to find in their readme [here](https://github.com/mozilla-services/react-jsonschema-form).

So then I started to look at other ways for us to accomplish our wildest dreams of having reusable schemas and came up with something a little different. I removed the fetch completely, because it seemed clunky to me and moved the form schemas inside the react app as opposed to in the public folder.

I understand this is a pretty big change and that this is a new eco-system for me so please give me feedback on this! Especially @wanderingstan as I think I'm re-working something that you put together and it may just be personal preference and in which case I can change it back in a heart beat!

Cheers!