### PR TITLE
Adding config to tell babel which browsers to support

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,13 @@
+# Setting supported browsers for babel so we don't get as many strange browser-related errors
+#
+# This file is consumed by @babel/preset-env, which is configured in package.json
+#
+# Docs here:
+# https://github.com/babel/babel/tree/master/packages/babel-preset-env
+#
+# See best practices here: 
+# https://github.com/browserslist/browserslist#best-practices
+
+last 1 version
+not dead
+> 0.2%


### PR DESCRIPTION
### Checklist:
- [x] Test your work and double check you didn't break anything

### Description:
- This should fix the issues we've been seeing on Safari <V10 (and a lot of other issues we haven't run into yet) 😀 
- Setting supported browsers for babel so we don't get as many strange browser-related errors
- This file is consumed by @babel/preset-env, which is configured in package.json
- Docs: https://github.com/babel/babel/tree/master/packages/babel-preset-env
- Best Practices for setting the values in this file: https://github.com/browserslist/browserslist#best-practices
