### PR TITLE
Adding script for Crowdin in-context translations

### DIFF
--- a/public/dev.html
+++ b/public/dev.html
@@ -5,6 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="favicon.ico">
     <title>Origin Protocol Demo DApp</title>
+
+    <script>
+      // If URL query string contains "?translator=true", run Crowdin's In Context Translation
+      // https://support.crowdin.com/in-context-localization/
+      // https://crowdin.com/project/originprotocol/settings#in-context
+      if (window.location.href.indexOf('translator=true') > -1) {
+        var _jipt = [];
+        _jipt.push(['project', 'originprotocol']);
+        var crowdinScript = document.createElement('script');
+        crowdinScript.setAttribute('src', '//cdn.crowdin.com/jipt/jipt.js');
+        document.head.appendChild(crowdinScript);
+      }
+    </script>
   </head>
   <body>
     <div id="root" class="d-flex flex-column">Please wait...</div>

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="favicon.ico">
     <title>Origin Protocol Demo DApp</title>
+
+    <script>
+      // If URL query string contains "?translator=true", run Crowdin's In Context Translation
+      // https://support.crowdin.com/in-context-localization/
+      // https://crowdin.com/project/originprotocol/settings#in-context
+      if (window.location.search.indexOf('translator=true') > -1) {
+        var _jipt = [];
+        _jipt.push(['project', 'originprotocol']);
+        var crowdinScript = document.createElement('script');
+        crowdinScript.setAttribute('src', '//cdn.crowdin.com/jipt/jipt.js');
+        document.head.appendChild(crowdinScript);
+      }
+    </script>
   </head>
   <body>
     <div id="root" class="d-flex flex-column">Please wait...</div>


### PR DESCRIPTION
### Checklist:
- [x] Test your work and double check you didn't break anything

### Description:
This enables in-context translation via Crowdin by using a query string `?translator=true`:
https://support.crowdin.com/in-context-localization/

I didn't document it yet because it seems like it's going to be kind of a pain to use and I'd rather try it out with the one translator who has asked for it before rolling it out more broadly.

To enable in-context translation in a new language, we have to:
1) Go here: https://crowdin.com/project/originprotocol/settings#in-context
2) select the language from the dropdown menu and build/download a special JSON file that has Crowdin-generated IDs for each message that needs translation
3) Commit that file to the DApp in a new directory like `/translations/languages/<new lang name>/all-messages.json` and deploy it
