### PR TITLE
Show modal during purchase stage updates

### DIFF
--- a/translations/all-messages.json
+++ b/translations/all-messages.json
@@ -198,6 +198,8 @@
   "purchase-detail.soldToOn": "Sold to {buyerName} on {date}",
   "purchase-detail.price": "Price",
   "purchase-detail.listingStatus": "This listing is {status}",
+  "purchase-detail.processingUpdate": "Processing your update",
+  "purchase-detail.pleaseStandBy": "Please stand by...",
   "purchase-progress.purchased": "Purchased",
   "purchase-progress.sentBySeller": "Sent by seller",
   "purchase-progress.receivedByMe": "Received by me",

--- a/translations/messages/src/components/purchase-detail.json
+++ b/translations/messages/src/components/purchase-detail.json
@@ -138,5 +138,13 @@
   {
     "id": "purchase-detail.listingStatus",
     "defaultMessage": "This listing is {status}"
+  },
+  {
+    "id": "purchase-detail.processingUpdate",
+    "defaultMessage": "Processing your update"
+  },
+  {
+    "id": "purchase-detail.pleaseStandBy",
+    "defaultMessage": "Please stand by..."
   }
 ]


### PR DESCRIPTION
This adds some UX feedback during the transaction processing for purchase stage updates. As we discussed recently, this should eventually be replaced by https://github.com/OriginProtocol/origin-dapp/issues/251 in accordance with https://github.com/OriginProtocol/origin-dapp/issues/85. Until then, this provides at least some improvement.