### PR TITLE
Issue #288 - render white circle for wallet icon when no address is provided

### DIFF
--- a/src/components/Identicon.js
+++ b/src/components/Identicon.js
@@ -1,8 +1,14 @@
 import React from 'react'
 import IdenticonJS from 'identicon.js'
 
-const Identicon = ({ address = '0x000000000000000000000000', size = 30 }) => {
-  const data = new IdenticonJS(address, size).toString()
+const Identicon = ({ address, size = 30 }) => {
+  let data = null
+  if (!address) {
+    // base64 encoded 1x1 blank white pixel when address is not defined
+    data = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII='
+  } else {
+    data = new IdenticonJS(address, size).toString()
+  }
 
   return (
     <img


### PR DESCRIPTION
This replaces the square red box generated by IdenticonJS with a blank white circle when the wallet address is not set. 

![ss](https://user-images.githubusercontent.com/489202/42427637-b6800b86-8383-11e8-8d72-d5d2080827dc.png)
