### PR TITLE
Fix wrong reference to intlMessages attribute

### DIFF
--- a/src/pages/profile/_ProvisionedChanges.js
+++ b/src/pages/profile/_ProvisionedChanges.js
@@ -137,7 +137,7 @@ class ProvisionedChanges extends Component {
             title={`
               <div class="text-left">
                 You are verifying:<br />
-                <img src="/images/checkmark-green.svg" alt="checkmark icon" /> ${this.props.intl.formatMessage(this.intlMessages.email)}<br />
+                <img src="/images/checkmark-green.svg" alt="checkmark icon" /> ${this.props.intl.formatMessage(this.intlMessages.emailAddress)}<br />
                 <br />
                 <img src="/images/eye-no.svg" alt="not-visible icon" /> <strong>${this.props.intl.formatMessage(this.intlMessages.notVisibleOnBlockchain)}</strong>
               </div>


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double check you didn't break anything
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

Fix broken reference which caused email attestation to break (blank screen and console errors) after a correct verification code is submitted.