### PR TITLE
Deal with block time in the future

### DIFF
--- a/src/components/transaction.js
+++ b/src/components/transaction.js
@@ -84,6 +84,8 @@ class Transaction extends Component {
     const decimal = confirmationCount / confirmationCompletionCount
     const percentage = Math.min(100, (decimal * 100).toFixed())
     const degreeIncrement = 360 / confirmationCompletionCount
+    // The block timestamp is somehow in the future when testing locally. - Micah
+    const timeReference = Math.min(created * 1000, Date.now())
 
     return (
       <li key={transactionHash} className="list-group-item d-flex align-items-stretch transaction">
@@ -96,7 +98,7 @@ class Transaction extends Component {
               />
             </div>
             <div className="timelapse ml-auto">
-              { moment(created * 1000).fromNow() }
+              { moment(timeReference).fromNow() }
             </div>
           </div>
           <div className="d-flex">


### PR DESCRIPTION
I don't know if this is only a local blockchain quirk or not, but I know that we can't entirely rely on block times since they can be manipulated by miners. This adds a safeguard so that [`fromNow`](https://momentjs.com/docs/#/displaying/fromnow/) does not produce "in a few seconds" or whatever.