### PR TITLE
Change crowdin config to use local not lang name

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,3 @@
 files:
   - source: /translations/all-messages.json
-    translation: /translations/languages/%language%/%original_file_name%
+    translation: /translations/languages/%locale%/%original_file_name%


### PR DESCRIPTION
### Description:
@wanderingstan 
Just a small tweak so that Crowdin commits the translated files to a directory named with the language's locale instead of the language name. Per Crowdin docs here:
https://support.crowdin.com/configuration-file/#placeholders

This will set the stage for another PR with more changes to make the scripts and stuff work with this new naming convention.

Issue: https://github.com/OriginProtocol/origin-dapp/issues/340