### PR TITLE
Replace 'Please Wait' with unicode clock

### DIFF
--- a/public/dev.html
+++ b/public/dev.html
@@ -20,6 +20,6 @@
     </script>
   </head>
   <body>
-    <div id="root" class="d-flex flex-column">Please wait...</div>
+    <div id="root" class="d-flex flex-column">&#128337;<!--Unicode Clock--></div>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
     </script>
   </head>
   <body>
-    <div id="root" class="d-flex flex-column">Please wait...</div>
+    <div id="root" class="d-flex flex-column">&#128337;<!--Unicode Clock--></div>
   <script type="text/javascript">
     /* Google Analytics */
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
For a localized DApp, it's not good that the first impression is an English string.

🕑 is a recognizable icon meaning "Please wait", and can do the job in a non-language specific manor.
