### PR TITLE
Adding dependencies from calendar_prototype branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "popper.js": "^1.14.3",
     "react": "^16.3.2",
     "react-avatar-editor": "^11.0.2",
+    "react-big-calendar": "^0.19.2",
     "react-dom": "^16.3.2",
     "react-intl": "^2.4.0",
     "react-js-pagination": "^3.0.2",
@@ -35,6 +36,7 @@
     "redux-thunk": "^2.2.0",
     "serve": "^6.5.6",
     "store": "^2.0.12",
+    "uuid": "^3.2.1",
     "web3": "^1.0.0-beta.34"
   },
   "devDependencies": {


### PR DESCRIPTION
This will save me many headaches as I switch back and forth to the `calendar_prototype` branch. Each time I switch branches, I have to delete and re-install my entire origin-box setup to get the dependencies to be found by webpack because of this bug:
https://github.com/OriginProtocol/origin-box/issues/34

If these dependencies (which will eventually be merged to master anyway) are here now, I can spend more time coding and less time cursing whoever invented docker...
