### PR TITLE
Hidelist hotfix

### DIFF
--- a/src/actions/Listing.js
+++ b/src/actions/Listing.js
@@ -19,8 +19,6 @@ export function getListingIds() {
 
     let hideList = []
     const { web3, listingsRegistryContract } = origin.contractService
-    const inProductionEnv =
-      window.location.hostname === 'demo.originprotocol.com'
 
     try {
       let networkId = await web3.eth.net.getId()
@@ -33,7 +31,7 @@ export function getListingIds() {
         return
       }
 
-      if (inProductionEnv && networkId < 10) {
+      if (networkId < 10) { // Networks >9 are local test networks
         let response = await fetch(
           `https://raw.githubusercontent.com/OriginProtocol/demo-dapp/hide_list/hidelist_${networkId}.json`
         )

--- a/src/actions/Listing.js
+++ b/src/actions/Listing.js
@@ -45,8 +45,7 @@ export function getListingIds() {
 
       dispatch({
         type: ListingConstants.FETCH_IDS_SUCCESS,
-        ids: showIds.reverse(),
-        hideList
+        ids: showIds.reverse()
       })
     } catch (error) {
       dispatch(showAlert(error.message))

--- a/src/components/listing-card.js
+++ b/src/components/listing-card.js
@@ -34,6 +34,11 @@ class ListingCard extends Component {
     const { address, category, loading, name, pictures, price, unitsAvailable } = this.state
     const photo = pictures && pictures.length && (new URL(pictures[0])).protocol === "data:" && pictures[0]
 
+    // Temporary fix to allow admins to see listing index for an address
+    if (address && this.props.listingId) {
+      console.log(`listing index for address ${address}:`, this.props.listingId)
+    }
+
     return (
       <div className={`col-12 col-md-6 col-lg-4 listing-card${loading ? ' loading' : ''}`}>
         <Link to={`/listing/${address}`}>

--- a/src/components/listing-card.js
+++ b/src/components/listing-card.js
@@ -13,32 +13,26 @@ class ListingCard extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      loading: true,
-      shouldRender: true
+      loading: true
     }
   }
 
   async componentDidMount() {
     try {
       const listing = await origin.listings.getByIndex(this.props.listingId)
-      const translatedListing = translateListingCategory(listing)
-      if (!this.props.hideList.includes(translatedListing.address)) {
-        const obj = Object.assign({}, translatedListing, { loading: false })
 
-        this.setState(obj)
-      } else {
-        this.setState({ shouldRender: false })
-      }
+      const translatedListing = translateListingCategory(listing)
+      const obj = Object.assign({}, translatedListing, { loading: false })
+
+      this.setState(obj)
     } catch (error) {
       console.error(`Error fetching contract or IPFS info for listingId: ${this.props.listingId}`)
     }
   }
 
   render() {
-    const { address, category, loading, name, pictures, price, unitsAvailable, shouldRender } = this.state
+    const { address, category, loading, name, pictures, price, unitsAvailable } = this.state
     const photo = pictures && pictures.length && (new URL(pictures[0])).protocol === "data:" && pictures[0]
-
-    if (!shouldRender) return false
 
     return (
       <div className={`col-12 col-md-6 col-lg-4 listing-card${loading ? ' loading' : ''}`}>

--- a/src/components/listings-grid.js
+++ b/src/components/listings-grid.js
@@ -22,7 +22,7 @@ class ListingsGrid extends Component {
 
   render() {
     const { listingsPerPage } = this.state
-    const { contractFound, listingIds, hideList } = this.props
+    const { contractFound, listingIds } = this.props
     const pinnedListingIds = [0, 1, 2, 3, 4]
     const activePage = this.props.match.params.activePage || 1
     const arrangedListingIds = [...pinnedListingIds, ...listingIds.filter(id => !pinnedListingIds.includes(id))]
@@ -62,7 +62,7 @@ class ListingsGrid extends Component {
             }
             <div className="row">
               {showListingsIds.map(listingId => (
-                <ListingCard listingId={listingId} key={listingId} hideList={hideList} />
+                <ListingCard listingId={listingId} key={listingId} />
               ))}
             </div>
             <Pagination
@@ -84,7 +84,6 @@ class ListingsGrid extends Component {
 
 const mapStateToProps = state => ({
   listingIds: state.listings.ids,
-  hideList: state.listings.hideList,
   contractFound: state.listings.contractFound
 })
 

--- a/src/reducers/Listings.js
+++ b/src/reducers/Listings.js
@@ -2,7 +2,6 @@ import { ListingConstants } from 'actions/Listing'
 
 const initialState = {
   ids: [],
-  hideList: [],
   contractFound: true
 }
 
@@ -13,7 +12,7 @@ export default function Listings(state = initialState, action = {}) {
         return { ...state, ids: [], contractFound: action.contractFound }
 
       case ListingConstants.FETCH_IDS_SUCCESS:
-        return { ...state, ids: action.ids, hideList: action.hideList }
+        return { ...state, ids: action.ids }
 
       default:
         return state


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any new text/strings for translation
- [x] Map any new environment variables with a default value in the Webpack config
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

Hotfix which re-adds commits from https://github.com/OriginProtocol/origin-dapp/pull/231 which were inadvertently removed. Allows us to hide listings by index rather than address, which allows us to paginate properly with the removed items, with no awkward whitespace on any pages.

I have already updated the `hide_list` branch to hide the latest blocked listings by index. So whenever this is merged/deployed the blocked listings will not reappear.