### PR TITLE
Repair user references

### DIFF
--- a/src/components/conversation.js
+++ b/src/components/conversation.js
@@ -130,7 +130,7 @@ class Conversation extends Component {
     const purchases = await Promise.all(purchaseAddresses.map(async addr => {
       return await origin.purchases.get(addr)
     }))
-    const involvingCounterparty = purchases.filter(p => p.buyerAddress === counterparty.address || p.buyerAddress === web3Account)
+    const involvingCounterparty = purchases.filter(p => p.buyer === counterparty.address || p.buyer === web3Account)
     const mostRecent = involvingCounterparty.sort((a, b) => a.index > b.index ? -1 : 1)[0]
     // purchase may not be found
     if (!mostRecent) {
@@ -160,8 +160,8 @@ class Conversation extends Component {
     const { id, intl, messages, web3Account } = this.props
     const { counterparty, listing, purchase } = this.state
     const { address, name, pictures } = listing
-    const { buyerAddress, created } = purchase
-    const perspective = buyerAddress ? (buyerAddress === web3Account ? 'buyer' : 'seller') : null
+    const { buyer, created } = purchase
+    const perspective = buyer ? (buyer === web3Account ? 'buyer' : 'seller') : null
     const soldAt = created ? created * 1000 /* convert seconds since epoch to ms */ : null
     const photo = pictures && pictures.length > 0 && (new URL(pictures[0])).protocol === 'data:' && pictures[0]
     const canDeliverMessage = origin.messaging.canConverseWith(counterparty.address)
@@ -177,7 +177,7 @@ class Conversation extends Component {
               </div>
             </div>
             <div className="content-container d-flex flex-column">
-              {buyerAddress &&
+              {buyer &&
                 <div className="brdcrmb">
                   {perspective === 'buyer' &&
                     <FormattedMessage
@@ -196,7 +196,7 @@ class Conversation extends Component {
                 </div>
               }
               <h1>{name}</h1>
-              {buyerAddress &&
+              {buyer &&
                 <div className="state">
                   {perspective === 'buyer' &&
                     <FormattedMessage
@@ -214,7 +214,7 @@ class Conversation extends Component {
                   }
                 </div>
               }
-              {buyerAddress &&
+              {buyer &&
                 <PurchaseProgress
                   purchase={purchase}
                   perspective={perspective}

--- a/src/components/dropdowns/notifications.js
+++ b/src/components/dropdowns/notifications.js
@@ -134,11 +134,11 @@ const mapStateToProps = ({ app, notifications }) => {
     // add perspective and filter
     notifications: notifications
       .map(n => {
-        const { sellerAddress } = n.resources.listing
+        const { seller } = n.resources.listing
 
         return {
           ...n,
-          perspective: app.web3.account === sellerAddress ? 'seller' : 'buyer'
+          perspective: app.web3.account === seller ? 'seller' : 'buyer'
         }
       })
       .filter(n => n.status === 'unread'),

--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -154,7 +154,7 @@ class ListingsDetail extends Component {
   render() {
     const isActive = this.state.status === 'active'
     const buyersReviews = this.state.reviews
-    const userIsSeller = this.state.sellerAddress === this.props.web3Account
+    const userIsSeller = this.state.seller === this.props.web3Account
 
     return (
       <div className="listing-detail">
@@ -324,7 +324,7 @@ class ListingsDetail extends Component {
                   <FormattedMessage
                     id={'listing-detail.seller'}
                     defaultMessage={'Seller: {sellerAddress}'}
-                    values={{ sellerAddress: this.state.sellerAddress }}
+                    values={{ sellerAddress: this.state.seller }}
                   />
                 </li>
                 <li>
@@ -433,11 +433,11 @@ class ListingsDetail extends Component {
                   )}
                 </div>
               )}
-              {this.state.sellerAddress && (
+              {this.state.seller && (
                 <UserCard
                   title="seller"
                   listingAddress={this.props.listingAddress}
-                  userAddress={this.state.sellerAddress}
+                  userAddress={this.state.seller}
                 />
               )}
             </div>

--- a/src/components/my-listings.js
+++ b/src/components/my-listings.js
@@ -32,9 +32,6 @@ class MyListings extends Component {
   /*
   * WARNING: These functions don't actually return what they might imply.
   * They use return statements to chain together async calls. Oops.
-  *
-  * For now, we mock a getBySellerAddress request by fetching all
-  * listings individually, filtering each by sellerAddress.
   */
 
   async loadListings() {

--- a/src/components/my-sale-card.js
+++ b/src/components/my-sale-card.js
@@ -35,7 +35,7 @@ class MySaleCard extends Component {
 
   componentWillMount() {
     this.props.fetchUser(
-      this.props.purchase.buyerAddress,
+      this.props.purchase.buyer,
       this.props.intl.formatMessage(this.intlMessages.unnamedUser)
     )
   }
@@ -184,7 +184,7 @@ class MySaleCard extends Component {
 
 const mapStateToProps = (state, { purchase }) => {
   return {
-    user: state.users.find(u => u.address === purchase.buyerAddress) || {}
+    user: state.users.find(u => u.address === purchase.buyer) || {}
   }
 }
 

--- a/src/components/notification.js
+++ b/src/components/notification.js
@@ -16,8 +16,8 @@ class Notification extends Component {
     const { notification, web3Account } = this.props
     const { listing, purchase } = notification.resources
     const counterpartyAddress = [
-      listing.sellerAddress,
-      purchase.buyerAddress
+      listing.seller,
+      purchase.buyer
     ].find(addr => addr !== web3Account)
 
     this.intlMessages = defineMessages({

--- a/src/components/notifications.js
+++ b/src/components/notifications.js
@@ -14,10 +14,10 @@ class Notifications extends Component {
     const { notifications, web3Account } = this.props
     const { filter } = this.state
     const notificationsWithPerspective = notifications.map(n => {
-      const { sellerAddress } = n.resources.listing
+      const { seller } = n.resources.listing
       return {
         ...n,
-        perspective: web3Account === sellerAddress ? 'seller' : 'buyer'
+        perspective: web3Account === seller ? 'seller' : 'buyer'
       }
     })
     const filteredNotifications =


### PR DESCRIPTION
This repairs the references to buyers and sellers in order to display the "About the {user}" cards, etc. This will need to be revisited once https://github.com/OriginProtocol/origin-js/issues/378 is settled. I will make another issue for that.