### PR TITLE
Fix my-purchase and my-sales

### DIFF
--- a/src/components/my-purchase-card.js
+++ b/src/components/my-purchase-card.js
@@ -6,6 +6,7 @@ import { defineMessages, injectIntl } from 'react-intl'
 import PurchaseProgress from 'components/purchase-progress'
 
 import { translateListingCategory } from 'utils/translationUtils'
+import { offerStatusToStep } from 'utils/offer'
 
 class MyPurchaseCard extends Component {
   constructor(props) {
@@ -52,7 +53,7 @@ class MyPurchaseCard extends Component {
     const { category, name, pictures, price } = translateListingCategory(
       listing.ipfsData.data
     )
-    const step = parseInt(offer.status)
+    const step = offerStatusToStep(offer.status)
     let verb
 
     switch (step) {

--- a/src/components/my-purchases.js
+++ b/src/components/my-purchases.js
@@ -6,6 +6,8 @@ import { storeWeb3Intent } from 'actions/App'
 
 import MyPurchaseCard from 'components/my-purchase-card'
 
+import { offerStatusToStep } from 'utils/offer'
+
 import origin from '../services/origin'
 
 class MyPurchases extends Component {
@@ -49,7 +51,7 @@ class MyPurchases extends Component {
   render() {
     const { filter, loading, purchases } = this.state
     const filteredPurchases = purchases.filter(obj => {
-      const step = Number(obj.offer.status)
+      const step = offerStatusToStep(obj.offer.status)
       if (filter === 'pending') {
         return step < 4
       } else if (filter === 'complete') {

--- a/src/components/my-sales.js
+++ b/src/components/my-sales.js
@@ -6,6 +6,8 @@ import { storeWeb3Intent } from 'actions/App'
 
 import MySaleCard from 'components/my-sale-card'
 
+import { offerStatusToStep} from '../utils/offer'
+
 import origin from '../services/origin'
 
 class MySales extends Component {
@@ -47,7 +49,7 @@ class MySales extends Component {
   render() {
     const { filter, loading, purchases } = this.state
     const filteredPurchases = purchases.filter(obj => {
-      const step = Number(obj.offer.status)
+      const step = offerStatusToStep(obj.offer.status)
       if (filter === 'pending') {
         return step < 4
       } else if (filter === 'complete') {

--- a/src/components/my-sales.js
+++ b/src/components/my-sales.js
@@ -6,7 +6,7 @@ import { storeWeb3Intent } from 'actions/App'
 
 import MySaleCard from 'components/my-sale-card'
 
-import { offerStatusToStep} from '../utils/offer'
+import { offerStatusToStep } from '../utils/offer'
 
 import origin from '../services/origin'
 


### PR DESCRIPTION
### Checklist:
- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:
The offer status returned by origin-js was [recently changed](https://github.com/OriginProtocol/origin-js/issues/402) from a number to a string. But the DApp relies on status being a number to determine the progress of the transaction. This PR does the translation.
Note that the DApp does not handle yet the "disputed" status correctly but that's out of scope for this PR.

