### PR TITLE
Wire up boost value to origin.js commissions

### DIFF
--- a/src/components/boost-slider.js
+++ b/src/components/boost-slider.js
@@ -3,53 +3,18 @@ import Slider from 'rc-slider'
 import $ from 'jquery'
 // TODO:John - pass a third arg of 'OGN' into getFiatPrice() once OGN prices are available in cryptonator API
 import { getFiatPrice } from 'utils/priceUtils'
+import { boostLevels, getBoostLevel } from 'utils/boostUtils'
 
 class BoostSlider extends Component {
   constructor(props) {
     super(props)
-    const { min, max, defaultValue, ognBalance } = this.props
-    const range = max - min
-    let defaultVal = defaultValue || 0
-    if (ognBalance === 0) {
-      defaultVal = 0
-    } else if (defaultValue > ognBalance) {
-      defaultVal = ognBalance
-    }
-
-    this.boostLevels = {
-      None: {
-        min: 0,
-        max: 0,
-        desc: 'Your listing will get very low visibility and no seller guarantee'
-      },
-      Low: {
-        min: min + 1,
-        max: (range / 4),
-        desc: 'Your listing will get below average visibility and low seller guarantee'
-      },
-      Medium: {
-        min: range / 4 + 1,
-        max: (range / 2),
-        desc: 'Your listing will get average visibility and good seller guarantee'
-      },
-      High: {
-        min: range / 2 + 1,
-        max: ((range / 4) * 3),
-        desc: 'Your listing will get above average visibility and excellent seller guarantee'
-      },
-      Premium: {
-        min: (range / 4) * 3 + 1,
-        max: max,
-        desc: 'Your listing will get the best visibility and highest seller guarantee'
-      }
-    }
+    const { defaultValue, ognBalance } = this.props
 
     this.onChange = this.onChange.bind(this)
-    this.getBoostLevel = this.getBoostLevel.bind(this)
 
     this.state = {
-      selectedBoostAmount: defaultVal,
-      boostLevel: this.getBoostLevel(defaultVal) || 0,
+      selectedBoostAmount: defaultValue,
+      boostLevel: getBoostLevel(defaultValue) || 0,
       selectedBoostAmountUsd: 0
     }
   }
@@ -66,21 +31,13 @@ class BoostSlider extends Component {
     $('[data-toggle="tooltip"]').tooltip('dispose')
   }
 
-  getBoostLevel(value) {
-    const { boostLevels } = this
-    for (const levelName in boostLevels) {
-      const thisLevel = boostLevels[levelName]
-      if (value >= thisLevel.min && value <= thisLevel.max) {
-        return levelName.toString()
-      }
-    }
-  }
-
   async onChange(value) {
+    const boostLevel = getBoostLevel(value)
     this.setState({
       selectedBoostAmount: value,
-      boostLevel: this.getBoostLevel(value)
+      boostLevel
     })
+    this.props.onChange(value, boostLevel)
     const selectedBoostAmountUsd = await getFiatPrice(value, 'USD')
     this.setState({
       selectedBoostAmountUsd
@@ -126,7 +83,7 @@ class BoostSlider extends Component {
           defaultValue={ this.state.selectedBoostAmount }
           min={ this.props.min }
           max={ this.props.max } />
-        <p className="text-italics">{ this.boostLevels[this.state.boostLevel].desc }</p>
+        <p className="text-italics">{ boostLevels[this.state.boostLevel].desc }</p>
         {this.props.ognBalance === 0 &&
           <div className="info-box">
             <p>You have 0 <a href="#" target="_blank" rel="noopener noreferrer">OGN</a> in your wallet and cannot boost.</p>

--- a/src/components/boost-slider.js
+++ b/src/components/boost-slider.js
@@ -73,7 +73,7 @@ class BoostSlider extends Component {
               <img src="images/ogn-icon.svg" role="presentation" />
               { this.state.selectedBoostAmount }&nbsp;
               <a href="#" target="_blank" rel="noopener noreferrer">OGN</a>
-              <span className="help-block"> | { this.state.selectedBoostAmountUsd } USD</span>
+              {/* <span className="help-block"> | { this.state.selectedBoostAmountUsd } USD</span> */}
             </p>
           </div>
         </div>

--- a/src/components/boost-slider.js
+++ b/src/components/boost-slider.js
@@ -8,8 +8,7 @@ import { boostLevels, getBoostLevel, defaultBoostValue, minBoostValue, maxBoostV
 class BoostSlider extends Component {
   constructor(props) {
     super(props)
-    const { ognBalance } = this.props
-
+    
     this.onChange = this.onChange.bind(this)
 
     this.state = {

--- a/src/components/boost-slider.js
+++ b/src/components/boost-slider.js
@@ -3,18 +3,18 @@ import Slider from 'rc-slider'
 import $ from 'jquery'
 // TODO:John - pass a third arg of 'OGN' into getFiatPrice() once OGN prices are available in cryptonator API
 import { getFiatPrice } from 'utils/priceUtils'
-import { boostLevels, getBoostLevel } from 'utils/boostUtils'
+import { boostLevels, getBoostLevel, defaultBoostValue, minBoostValue, maxBoostValue } from 'utils/boostUtils'
 
 class BoostSlider extends Component {
   constructor(props) {
     super(props)
-    const { defaultValue, ognBalance } = this.props
+    const { ognBalance } = this.props
 
     this.onChange = this.onChange.bind(this)
 
     this.state = {
-      selectedBoostAmount: defaultValue,
-      boostLevel: getBoostLevel(defaultValue) || 0,
+      selectedBoostAmount: defaultBoostValue,
+      boostLevel: getBoostLevel(defaultBoostValue) || 0,
       selectedBoostAmountUsd: 0
     }
   }
@@ -81,8 +81,8 @@ class BoostSlider extends Component {
           className={ `boost-level-${this.state.boostLevel}` }
           onChange={ this.onChange }
           defaultValue={ this.state.selectedBoostAmount }
-          min={ this.props.min }
-          max={ this.props.max } />
+          min={ minBoostValue }
+          max={ maxBoostValue } />
         <p className="text-italics">{ boostLevels[this.state.boostLevel].desc }</p>
         {this.props.ognBalance === 0 &&
           <div className="info-box">

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -105,9 +105,8 @@ class ListingCreate extends Component {
     ]
 
     this.state = {
-      // TODO:John - wire up ognBalance and isFirstListing when ready
-      ognBalance: 0,
-      isFirstListing: false,
+      // TODO:John - wire up isFirstListing when ready
+      isFirstListing: true,
       step: this.STEP.PICK_SCHEMA,
       selectedSchemaType: null,
       selectedSchema: null,
@@ -306,9 +305,10 @@ class ListingCreate extends Component {
 
   render() {
     const { wallet } = this.props
-    const { currentProvider, formListing, isBoostExpanded, isFirstListing, ognBalance, selectedSchema, selectedSchemaType, schemaExamples, step, translatedSchema, usdListingPrice } = this.state
+    const { currentProvider, formListing, isBoostExpanded, isFirstListing, selectedSchema, selectedSchemaType, schemaExamples, step, translatedSchema, usdListingPrice } = this.state
     const { formData } = formListing
     const translatedFormData = (formData && formData.category && translateListingCategory(formData)) || {}
+    const needsBoostTutorial = isFirstListing && !wallet.ognBalance
 
     return (
       <div className="container listing-form">
@@ -425,7 +425,7 @@ class ListingCreate extends Component {
                   />
                 </label>
                 <h2>Boost your listing</h2>
-                {isFirstListing &&
+                {needsBoostTutorial &&
                   <div className="info-box">
                     <img src="images/ogn-icon-horiz.svg" role="presentation" />
                     <p className="text-bold">You have 0 <a href="#" arget="_blank" rel="noopener noreferrer">OGN</a> in your wallet.</p>
@@ -451,11 +451,12 @@ class ListingCreate extends Component {
                     }
                   </div>
                 }
-                {!isFirstListing &&
+                {!needsBoostTutorial &&
                   <BoostSlider
                     onChange={ this.onBoostSliderChange }
-                    ognBalance={ ognBalance }
-                    defaultValue={ (formData && formData.boostValue) || defaultBoostValue } 
+                    ognBalance={ wallet.ognBalance }
+                    defaultValue={ (formData && formData.boostValue) || defaultBoostValue }
+                    max={1000}
                   />
                 }
                 <div className="btn-container">

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -456,7 +456,6 @@ class ListingCreate extends Component {
                     onChange={ this.onBoostSliderChange }
                     ognBalance={ wallet.ognBalance }
                     defaultValue={ (formData && formData.boostValue) || defaultBoostValue }
-                    max={1000}
                   />
                 }
                 <div className="btn-container">

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -19,6 +19,7 @@ import WalletCard from 'components/wallet-card'
 import { dappFormDataToOriginListing } from 'utils/listing'
 import getCurrentProvider from 'utils/getCurrentProvider'
 import { getFiatPrice } from 'utils/priceUtils'
+import { getBoostLevel, defaultBoostValue } from 'utils/boostUtils'
 import { translateSchema, translateListingCategory } from 'utils/translationUtils'
 
 import origin from '../services/origin'
@@ -113,7 +114,12 @@ class ListingCreate extends Component {
       translatedSchema: null,
       schemaExamples: null,
       schemaFetched: false,
-      formListing: { formData: null },
+      formListing: {
+        formData: {
+          boostValue: defaultBoostValue,
+          boostLevel: getBoostLevel(defaultBoostValue)
+        }
+      },
       currentProvider: getCurrentProvider(
         origin && origin.contractService && origin.contractService.web3
       ),
@@ -126,6 +132,7 @@ class ListingCreate extends Component {
     this.onBoostSelected = this.onBoostSelected.bind(this)
     this.toggleBoostBox = this.toggleBoostBox.bind(this)
     this.updateUsdPrice = this.updateUsdPrice.bind(this)
+    this.onBoostSliderChange = this.onBoostSliderChange.bind(this)
   }
 
   async updateUsdPrice() {
@@ -225,7 +232,14 @@ class ListingCreate extends Component {
       )
     } else {
       this.setState({
-        formListing: formListing,
+        formListing: {
+          ...this.state.formListing,
+          ...formListing,
+          formData: {
+            ...this.state.formListing.formData,
+            ...formListing.formData
+          }
+        },
         step: this.STEP.BOOST
       })
       window.scrollTo(0, 0)
@@ -239,6 +253,19 @@ class ListingCreate extends Component {
     })
     window.scrollTo(0, 0)
     this.updateUsdPrice()
+  }
+
+  onBoostSliderChange(boostValue, boostLevel) {
+    this.setState({
+      formListing: {
+        ...this.state.formListing,
+        formData: {
+          ...this.state.formListing.formData,
+          boostValue,
+          boostLevel
+        }
+      }
+    })
   }
 
   async onSubmitListing(formListing, selectedSchemaType) {
@@ -425,7 +452,11 @@ class ListingCreate extends Component {
                   </div>
                 }
                 {!isFirstListing &&
-                  <BoostSlider ognBalance={ ognBalance } min={ 0 } max={ 100 } defaultValue={ 50 } />
+                  <BoostSlider
+                    onChange={ this.onBoostSliderChange }
+                    ognBalance={ ognBalance }
+                    defaultValue={ (formData && formData.boostValue) || defaultBoostValue } 
+                  />
                 }
                 <div className="btn-container">
                   <button
@@ -531,13 +562,13 @@ class ListingCreate extends Component {
                       <p className="label">Boost Level</p>
                     </div>
                     <div className="col-md-9">
-                      <p className="boost-level">Medium</p>
+                      <p className="boost-level">{ translatedFormData.boostLevel }</p>
                       <p>
                         <img className="ogn-icon" src="images/ogn-icon.svg" role="presentation" />
-                        <span className="text-bold">20</span>&nbsp;
+                        <span className="text-bold">{ translatedFormData.boostValue }</span>&nbsp;
                         <a className="ogn-abbrev" href="#" target="_blank" rel="noopener noreferrer">OGN</a>
                         <span className="help-block">
-                          &nbsp;| 2.50 USD&nbsp;
+                          &nbsp;| x.xx USD&nbsp;
                           <span className="text-uppercase">(Approximate Value)</span>
                         </span>
                       </p>

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -567,10 +567,12 @@ class ListingCreate extends Component {
                         <img className="ogn-icon" src="images/ogn-icon.svg" role="presentation" />
                         <span className="text-bold">{ translatedFormData.boostValue }</span>&nbsp;
                         <a className="ogn-abbrev" href="#" target="_blank" rel="noopener noreferrer">OGN</a>
+                        {/*
                         <span className="help-block">
                           &nbsp;| x.xx USD&nbsp;
                           <span className="text-uppercase">(Approximate Value)</span>
                         </span>
+                        */}
                       </p>
                     </div>
                   </div>

--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -54,9 +54,8 @@ class ListingsDetail extends Component {
       currentProvider: getCurrentProvider(
         origin && origin.contractService && origin.contractService.web3
       ),
-      // TODO:John - wire up boost level & boost amount to actual data
-      boostLevel: 'Medium',
-      boostAmount: 10
+      boostLevel: null,
+      boostValue: 0
     }
 
     this.intlMessages = defineMessages({
@@ -413,7 +412,7 @@ class ListingsDetail extends Component {
                           <p>{ boostLevel }</p>
                           <p>
                             <img src="images/ogn-icon.svg" role="presentation" />
-                            <span className="font-bold">{ boostAmount }</span>&nbsp;
+                            <span className="font-bold">{ boostValue }</span>&nbsp;
                             <span className="font-blue font-bold">OGN</span>
                             <span className="help-block">1.00 USD</span>
                           </p>

--- a/src/utils/boostUtils.js
+++ b/src/utils/boostUtils.js
@@ -1,5 +1,5 @@
 const min = 0
-const max = 100
+const max = 1000
 const range = max - min
 
 export const defaultBoostValue = 50

--- a/src/utils/boostUtils.js
+++ b/src/utils/boostUtils.js
@@ -8,27 +8,27 @@ export const boostLevels = {
   None: {
     min: 0,
     max: 0,
-    desc: 'Your listing will get very low visibility and no seller guarantee'
+    desc: 'Your listing will get very low visibility.'
   },
   Low: {
     min: min + 1,
     max: (range / 4),
-    desc: 'Your listing will get below average visibility and low seller guarantee'
+    desc: 'Your listing will get below-average visibility.'
   },
   Medium: {
     min: range / 4 + 1,
     max: (range / 2),
-    desc: 'Your listing will get average visibility and good seller guarantee'
+    desc: 'Your listing will get average visibility.'
   },
   High: {
     min: range / 2 + 1,
     max: ((range / 4) * 3),
-    desc: 'Your listing will get above average visibility and excellent seller guarantee'
+    desc: 'Your listing will get above-average visibility.'
   },
   Premium: {
     min: (range / 4) * 3 + 1,
     max: max,
-    desc: 'Your listing will get the best visibility and highest seller guarantee'
+    desc: 'Your listing will get the best visibility.'
   }
 }
 

--- a/src/utils/boostUtils.js
+++ b/src/utils/boostUtils.js
@@ -1,0 +1,58 @@
+const min = 0
+const max = 100
+const range = max - min
+
+export const defaultBoostValue = 50
+
+export const boostLevels = {
+  None: {
+    min: 0,
+    max: 0,
+    desc: 'Your listing will get very low visibility and no seller guarantee'
+  },
+  Low: {
+    min: min + 1,
+    max: (range / 4),
+    desc: 'Your listing will get below average visibility and low seller guarantee'
+  },
+  Medium: {
+    min: range / 4 + 1,
+    max: (range / 2),
+    desc: 'Your listing will get average visibility and good seller guarantee'
+  },
+  High: {
+    min: range / 2 + 1,
+    max: ((range / 4) * 3),
+    desc: 'Your listing will get above average visibility and excellent seller guarantee'
+  },
+  Premium: {
+    min: (range / 4) * 3 + 1,
+    max: max,
+    desc: 'Your listing will get the best visibility and highest seller guarantee'
+  }
+}
+
+/*
+ * getBoostLevel
+ *
+ * @description determines the name of the boost level when given a boost value
+ * @param {number} value - the number of OGN that has is being offered for the boost
+ * @return {string} - the name of the boost level (Low, Medium, Premium, etc.)
+ */
+
+export const getBoostLevel = (value) => {
+  if (!value) {
+    value = 0
+  }
+
+  if (typeof value === 'string') {
+    value = parseFloat(value)
+  }
+
+  for (const levelName in boostLevels) {
+    const thisLevel = boostLevels[levelName]
+    if (value >= thisLevel.min && value <= thisLevel.max) {
+      return levelName.toString()
+    }
+  }
+}

--- a/src/utils/boostUtils.js
+++ b/src/utils/boostUtils.js
@@ -1,8 +1,7 @@
-const min = 0
-const max = 1000
-const range = max - min
-
-export const defaultBoostValue = 50
+export const defaultBoostValue = 500
+export const minBoostValue = 0
+export const maxBoostValue = 1000
+const range = maxBoostValue - minBoostValue
 
 export const boostLevels = {
   None: {
@@ -11,7 +10,7 @@ export const boostLevels = {
     desc: 'Your listing will get very low visibility.'
   },
   Low: {
-    min: min + 1,
+    min: minBoostValue + 1,
     max: (range / 4),
     desc: 'Your listing will get below-average visibility.'
   },
@@ -27,7 +26,7 @@ export const boostLevels = {
   },
   Premium: {
     min: (range / 4) * 3 + 1,
-    max: max,
+    max: maxBoostValue,
     desc: 'Your listing will get the best visibility.'
   }
 }

--- a/src/utils/boostUtils.js
+++ b/src/utils/boostUtils.js
@@ -44,10 +44,6 @@ export function getBoostLevel(value) {
     value = 0
   }
 
-  if (typeof value === 'string') {
-    value = parseFloat(value)
-  }
-
   for (const levelName in boostLevels) {
     const thisLevel = boostLevels[levelName]
     if (value >= thisLevel.min && value <= thisLevel.max) {

--- a/src/utils/boostUtils.js
+++ b/src/utils/boostUtils.js
@@ -39,7 +39,7 @@ export const boostLevels = {
  * @return {string} - the name of the boost level (Low, Medium, Premium, etc.)
  */
 
-export const getBoostLevel = (value) => {
+export function getBoostLevel(value) {
   if (!value) {
     value = 0
   }

--- a/src/utils/listing.js
+++ b/src/utils/listing.js
@@ -57,7 +57,7 @@ export function dappFormDataToOriginListing(formData) {
  * @return {object} DApp compatible listing object.
  */
 export function originToDAppListing(originListing) {
-  const commission = originListing.commission ? parseFloat(originListing.commission.amount) : 0.0
+  const commission = originListing.commission ? parseFloat(originListing.commission.amount) : 0
   return {
     id: originListing.id,
     seller: originListing.seller,

--- a/src/utils/listing.js
+++ b/src/utils/listing.js
@@ -1,4 +1,5 @@
 import { translateListingCategory } from 'utils/translationUtils'
+import { getBoostLevel } from 'utils/boostUtils'
 import origin from '../services/origin'
 
 
@@ -25,6 +26,10 @@ export function dappFormDataToOriginListing(formData) {
     price: {
       amount: formData.price.toString(),
       currency: 'ETH'
+    },
+    commission: {
+      amount: formData.boostValue.toString(),
+      currency: 'OGN'
     }
   }
 
@@ -60,6 +65,8 @@ export function originToDAppListing(originListing) {
     name: originListing.title,
     pictures: originListing.media ? originListing.media.map(medium => medium.url) : [],
     price: originListing.price.amount,
+    boostValue: originListing.commission && originListing.commission.amount,
+    boostLevel: getBoostLevel(originListing.commission && originListing.commission.amount),
     unitsRemaining: originListing.unitsRemaining,
     ipfsHash: originListing.ipfs.hash
   }

--- a/src/utils/listing.js
+++ b/src/utils/listing.js
@@ -57,6 +57,7 @@ export function dappFormDataToOriginListing(formData) {
  * @return {object} DApp compatible listing object.
  */
 export function originToDAppListing(originListing) {
+  const commission = originListing.commission ? parseFloat(originListing.commission.amount) : 0.0
   return {
     id: originListing.id,
     seller: originListing.seller,
@@ -65,8 +66,8 @@ export function originToDAppListing(originListing) {
     name: originListing.title,
     pictures: originListing.media ? originListing.media.map(medium => medium.url) : [],
     price: originListing.price.amount,
-    boostValue: originListing.commission && originListing.commission.amount,
-    boostLevel: getBoostLevel(originListing.commission && originListing.commission.amount),
+    boostValue: commission,
+    boostLevel: getBoostLevel(commission),
     unitsRemaining: originListing.unitsRemaining,
     ipfsHash: originListing.ipfs.hash
   }


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything

### Description:

This wires up the boost slider to origin.js so that boost value gets stored as commission price in IPFS. 

This can be merged when approved. There is still be additional work to do in origin.js to enable payment of commissions, etc.
