### PR TITLE
Description field wasn’t being carried over into the dapp.

### DIFF
--- a/src/utils/listing.js
+++ b/src/utils/listing.js
@@ -65,6 +65,7 @@ export function originToDAppListing(originListing) {
     status: originListing.status,
     category: originListing.subCategory,
     name: originListing.title,
+    description: originListing.description,
     pictures: originListing.media
       ? originListing.media.map(medium => medium.url)
       : [],


### PR DESCRIPTION
We have a function that maps the names of things in origin.js to the names of things in the dapp. The "description" field wasn’t being carried over into the dapp.

Fixed that.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any new text/strings for translation
- [x] Map any new environment variables with a default value in the Webpack config
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
