### PR TITLE
Changed unnecessary absolute paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM node:8
 ENV NPM_CONFIG_LOGLEVEL warn
 WORKDIR /src
-COPY package.json /src/
-COPY package-lock.json /src/
-COPY truffle.js /src/
-COPY contracts /src/contracts/
-COPY migrations /src/migrations/
+COPY package.json ./
+COPY package-lock.json ./
+COPY truffle.js ./
+COPY contracts ./contracts/
+COPY migrations ./migrations/
 COPY bin/docker-truffle.sh /bin/docker-truffle.sh
 RUN npm install
 RUN npm install -g truffle


### PR DESCRIPTION
Since `WORKDIR` has already been set to `/src`, it is unnecessary to use absolute paths to target locations within this working directory. Using `./` is enough as commands following `WORKDIR` will take `/src` as the current location. 
Only when a different path outside of `/src` needs to be accessed, like `/bin/docker-truffle.sh` in `COPY bin/docker-truffle.sh /bin/docker-truffle.sh`, would we need to use absolute paths.

First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

Please explain the changes you made here:

- A description of the problem you're trying to solve
- An overview of the suggested solution
- If the feature changes current behavior, reasons why your solution is better
