### PR TITLE
Fix call to marketplace.getListings to add idsOnly option

### DIFF
--- a/src/components/my-listings.js
+++ b/src/components/my-listings.js
@@ -38,6 +38,7 @@ class MyListings extends Component {
   async loadListings() {
     try {
       const ids = await origin.marketplace.getListings({
+        idsOnly: true,
         listingsFor: this.props.web3Account
       })
       const listings = await Promise.all(

--- a/src/components/my-purchases.js
+++ b/src/components/my-purchases.js
@@ -23,7 +23,7 @@ class MyPurchases extends Component {
 
   async componentWillMount() {
     const purchasesFor = await origin.contractService.currentAccount()
-    const listingIds = await origin.marketplace.getListings({ purchasesFor })
+    const listingIds = await origin.marketplace.getListings({ idsOnly: true, purchasesFor })
     const listingPromises = listingIds.map(listingId => {
       return new Promise(async resolve => {
         const listing = await getListing(listingId)

--- a/src/components/my-sales.js
+++ b/src/components/my-sales.js
@@ -25,7 +25,7 @@ class MySales extends Component {
 
   async componentWillMount() {
     const listingsFor = await origin.contractService.currentAccount()
-    const listingIds = await origin.marketplace.getListings({ listingsFor })
+    const listingIds = await origin.marketplace.getListings({ idsOnly: true, listingsFor })
     const listingPromises = listingIds.map(listingId => {
       return new Promise(async resolve => {
         const listing = await getListing(listingId)


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:
I'm not positive but I think a recent refactor probably changed the behavior of the marketplace.getListings origin-js API. It now expects the options "idsOnly" to be set to return listingIds, otherwise it returns Listings.

