### PR TITLE
Remove schemaVersion in IPFS data

### DIFF
--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -126,7 +126,6 @@ class ListingsDetail extends Component {
         const offerData = {
           listingId: this.props.listingId,
           listingType: 'unit',
-          schemaVersion: '1.0.0',
           unitsPurchased: 1,
           totalPrice: {
             amount: this.state.price,

--- a/src/components/purchase-detail.js
+++ b/src/components/purchase-detail.js
@@ -265,7 +265,6 @@ class PurchaseDetail extends Component {
       this.setState({ processing: true })
 
       const buyerReview = {
-        schemaVersion: '1.0.0',
         rating,
         text: reviewText.trim()
       }
@@ -342,7 +341,6 @@ class PurchaseDetail extends Component {
       this.setState({ processing: true })
 
       const sellerReview = {
-        schemaVersion: '1.0.0',
         rating,
         text: reviewText.trim()
       }

--- a/src/utils/listing.js
+++ b/src/utils/listing.js
@@ -14,7 +14,6 @@ export function dappFormDataToOriginListing(formData) {
   const [category, subCategory] = formData.category.split('.').slice(1)
 
   const listingData = {
-    schemaVersion: '1.0.0',
     category: category,
     subCategory: subCategory,
     language: 'en-US', // TODO(franck) Get language from DApp.


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:
After the changes introduced in [origin-js PR 451](https://github.com/OriginProtocol/origin-js/pull/451), it is no longer needed to pass the "schemaVersion" field when calling origin-js marketplace methods that store data in IPFS.
