### PR TITLE
Natasha/modal blocking ui

### DIFF
--- a/src/components/modal.js
+++ b/src/components/modal.js
@@ -3,12 +3,10 @@ import $ from 'jquery'
 
 class Modal extends Component {
   componentDidMount() {
+    const { isOpen, backdrop = true } = this.props
     this.$el = $(this.el)
 
-    this.$el.modal({
-      backdrop: this.props.backdrop || true,
-      show: this.props.isOpen
-    })
+    this.$el.modal({backdrop, show: isOpen})
   }
 
   componentDidUpdate(prevProps) {
@@ -24,7 +22,7 @@ class Modal extends Component {
   }
 
   render() {
-    const { children, className } = this.props
+    const { children, className, tabIndex = "-1" } = this.props
 
     return (
       <div
@@ -32,7 +30,7 @@ class Modal extends Component {
         className={`modal fade ${this.props['data-modal']}${
           className ? ` ${className}` : ''
         }`}
-        tabIndex="-1"
+        tabIndex={tabIndex}
         role="dialog"
         aria-hidden="true"
       >

--- a/src/components/modal.js
+++ b/src/components/modal.js
@@ -6,7 +6,7 @@ class Modal extends Component {
     const { isOpen, backdrop = true } = this.props
     this.$el = $(this.el)
 
-    this.$el.modal({backdrop, show: isOpen})
+    this.$el.modal({ backdrop, show: isOpen })
   }
 
   componentDidUpdate(prevProps) {
@@ -22,7 +22,7 @@ class Modal extends Component {
   }
 
   render() {
-    const { children, className, tabIndex = "-1" } = this.props
+    const { children, className, tabIndex = '-1' } = this.props
 
     return (
       <div

--- a/src/components/onboarding-modal/index.js
+++ b/src/components/onboarding-modal/index.js
@@ -19,13 +19,13 @@ class OnboardingModal extends Component {
     this.closeModal = this.closeModal.bind(this)
   }
 
-  async componentWillMount() {
-    const { fetchSteps, onboarding, wallet } = this.props
+  async componentDidMount() {
+    const { fetchSteps } = this.props
     await fetchSteps()
 
-    if (!onboarding.stepsCompleted && !wallet.address) {
+    window.setTimeout(() => {
       this.userProgress()
-    }
+    }, 500)
   }
 
   componentWillUpdate(nextProps) {
@@ -36,7 +36,9 @@ class OnboardingModal extends Component {
     if (splitPanel) {
       this.addModalClass()
     } else {
-      this.removeModalClasses()
+      window.setTimeout(() => {
+        this.userProgress()
+      }, 500)
     }
   }
 
@@ -60,37 +62,34 @@ class OnboardingModal extends Component {
   }
 
   removeModalClasses() {
-    const { onboarding, wallet } = this.props
+    document.body.classList.remove('modal-open')
 
-    if (!wallet.address) {
-      document.body.classList.remove('modal-open')
-
-      if (!onboarding.splitPanel) {
-        const backdrop = document.getElementsByClassName('modal-backdrop')
-        backdrop.length && backdrop[0].classList.remove('modal-backdrop')
-      }
-    }
+    const backdrop = document.getElementsByClassName('modal-backdrop')
+    backdrop.length && backdrop[0].classList.remove('modal-backdrop')
   }
 
   userProgress() {
     const {
-      onboarding: { progress, stepsCompleted },
+      onboarding: { progress, learnMore },
       toggleLearnMore,
       toggleSplitPanel,
       wallet
     } = this.props
 
-    if (!wallet.address) {
-      if (!progress) {
-        this.removeModalClasses()
-        return toggleLearnMore(true)
-      } else if (!stepsCompleted && progress) {
-        this.addModalClass()
-        return toggleSplitPanel(true)
-      }
+    if (wallet.address) {
+      if (!learnMore) return
+      this.removeModalClasses()
+      return toggleLearnMore(false)
+    }
+
+    if (!progress && !learnMore) {
+      this.removeModalClasses()
+      toggleLearnMore(true)
+    } else if (progress) {
+      this.addModalClass()
+      return toggleSplitPanel(true)
     }
     this.removeModalClasses()
-    this.props.toggleLearnMore(false)
   }
 
   render() {
@@ -132,6 +131,8 @@ class OnboardingModal extends Component {
             className={'getting-started'}
             isOpen={learnMore}
             children={learnMoreContent}
+            tabIndex={'false'}
+            backdrop={false}
           />
         )}
         {splitPanel && (

--- a/src/components/onboarding-modal/index.js
+++ b/src/components/onboarding-modal/index.js
@@ -30,10 +30,10 @@ class OnboardingModal extends Component {
 
   componentWillUpdate(nextProps) {
     const {
-      onboarding: { splitPanel }
+      onboarding: { splitPanel, stepsCompleted }
     } = nextProps
 
-    if (splitPanel) {
+    if (splitPanel && !stepsCompleted) {
       this.addModalClass()
     } else {
       window.setTimeout(() => {
@@ -70,13 +70,13 @@ class OnboardingModal extends Component {
 
   userProgress() {
     const {
-      onboarding: { progress, learnMore },
+      onboarding: { progress, learnMore, stepsCompleted },
       toggleLearnMore,
       toggleSplitPanel,
       wallet
     } = this.props
 
-    if (wallet.address) {
+    if (wallet.address || stepsCompleted) {
       if (!learnMore) return
       this.removeModalClasses()
       return toggleLearnMore(false)


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- ~~[ ] Wrap any new text/strings for translation~~
- ~~[ ] Map any new environment variables with a default value in the Webpack config~~
- ~~[ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)~~

### Description:
[Issue #497](https://github.com/OriginProtocol/origin-dapp/issues/497)

Bugs:
- The default modal component blocks a user from interacting with input fields
  - the attribute `tabIndex='-1'` was the source of this behavior
- Navigating back to the Listings page using browser navigation => the getting started modal blocked the UI completely while open.

Fixes:
- refactor the modal component to take a `tabIndex` prop && default this to `-1`
- update the onboarding index component:
  - to wait for a wallet to load if it exists
  - to no longer show the modals if the user has completed all the steps
    - this means that currently a user can 'go through all the steps', not have a wallet and the modals will not show. Once the functionality of the modals have been implemented this should work as intended.
    - to reset the behavior, delete any onboarding data in localStorage
  - to no longer show the modals if the user has a `wallet.address`

![image](https://user-images.githubusercontent.com/17957496/45526659-46c31400-b795-11e8-93d7-1daa18a4b020.png)
