### PR TITLE
Listing Creation: Prevent Accidental Form Unload

### DIFF
--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, Prompt } from 'react-router-dom'
 import { connect } from 'react-redux'
-import { FormattedMessage, injectIntl } from 'react-intl'
+import { FormattedMessage, defineMessages, injectIntl } from 'react-intl'
 import Form from 'react-jsonschema-form'
 
 import { showAlert } from 'actions/Alert'
@@ -74,6 +74,13 @@ class ListingCreate extends Component {
       showBoostTutorial: false,
       usdListingPrice: 0
     }
+
+    this.intlMessages = defineMessages({
+      navigationWarning: {
+        id: 'listing-create.navigationWarning',
+        defaultMessage: 'Are you sure you want to leave? If you leave this page your progress will be lost.'
+      }
+    })
 
     this.checkOgnBalance = this.checkOgnBalance.bind(this)
     this.handleSchemaSelection = this.handleSchemaSelection.bind(this)
@@ -266,7 +273,7 @@ class ListingCreate extends Component {
     })
 
     window.scrollTo(0, 0)
-    
+
     this.updateUsdPrice()
   }
 
@@ -309,11 +316,12 @@ class ListingCreate extends Component {
   }
 
   render() {
-    const { wallet } = this.props
+    const { wallet, intl } = this.props
     const {
       currentProvider,
       formListing,
       isBoostExpanded,
+      schemaFetched,
       selectedSchema,
       selectedSchemaType,
       schemaExamples,
@@ -952,6 +960,10 @@ class ListingCreate extends Component {
             )}
           </div>
         </div>
+        <Prompt
+          when={schemaFetched}
+          message={intl.formatMessage(this.intlMessages.navigationWarning)}
+        />
       </div>
     )
   }

--- a/translations/all-messages.json
+++ b/translations/all-messages.json
@@ -72,6 +72,7 @@
   "listing-card-prices.ethereumCurrencyAbbrev": "ETH",
   "listing-card.pending": "Pending",
   "listing-card.sold": "Sold Out",
+  "listing-create.navigationWarning": "Are you sure you want to leave? If you leave this page your progress will be lost.",
   "listing-create.stepNumberLabel": "STEP {stepNumber}",
   "listing-create.whatTypeOfListing": "What type of listing do you want to create?",
   "listing-create.next": "Next",

--- a/translations/messages/src/components/listing-create.json
+++ b/translations/messages/src/components/listing-create.json
@@ -1,5 +1,9 @@
 [
   {
+    "id": "listing-create.navigationWarning",
+    "defaultMessage": "Are you sure you want to leave? If you leave this page your progress will be lost."
+  },
+  {
     "id": "listing-create.stepNumberLabel",
     "defaultMessage": "STEP {stepNumber}"
   },


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any new text/strings for translation
- ~~[ ] Map any new environment variables with a default value in the Webpack config~~
- ~~[ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)~~

### Description:
[Issue #496](https://github.com/OriginProtocol/origin-dapp/issues/496)

Problem:
- Listing creation is a multi-step/multi-component process where the state is handled in the component(s). So if a user navigates away from creating a listing (browser back button or router link), their progress is lost.

Solution:
- use react-router to prompt a warning when a user attempts to navigate from the create a listing process if they have started.

![image](https://user-images.githubusercontent.com/17957496/45695343-7455e780-bb1e-11e8-8fcd-0fd98f1cfe59.png)

