### PR TITLE
Issue #513 - create listing - fix price validation bug

### DIFF
--- a/src/components/form-widgets/price-field.js
+++ b/src/components/form-widgets/price-field.js
@@ -38,18 +38,18 @@ class PriceField extends Component {
       if (valueNum < 0) {
         return
       }
-      this.setState({
-        price: valueNum
-      })
+      this.setState(
+        {
+          price: valueNum
+        },
+        () => this.props.onChange(valueNum)
+      )
 
       if (!isNan) {
         const priceUsd = await getFiatPrice(valueNum, this.state.currencyCode)
-        this.setState(
-          {
-            priceUsd
-          },
-          () => this.props.onChange(valueNum)
-        )
+        this.setState({
+          priceUsd
+        })
       }
     }
   }


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything

### Description:

This bug was happening because the price field form widget wasn't calling the callback that notified the the parent form of the user's input until after the `getFiatPrice()` method returned a value. If `getFiatPrice()` failed, the widget's callback never was called and the parent form never knew that a price had been entered, so the validation failed since price is a required field.

Now, the callback gets called regardless of the success or failure of `getFiatPrice()`.