### PR TITLE
Boosted Listing Creation Improvements

### DIFF
--- a/src/components/boost-slider.js
+++ b/src/components/boost-slider.js
@@ -6,7 +6,6 @@ import $ from 'jquery'
 import {
   boostLevels,
   getBoostLevel,
-  defaultBoostValue,
   minBoostValue,
   maxBoostValue
 } from 'utils/boostUtils'
@@ -15,12 +14,7 @@ class BoostSlider extends Component {
   constructor(props) {
     super(props)
 
-    const selectedBoostAmount = props.ognBalance ? defaultBoostValue : 0
-
-    this.state = {
-      selectedBoostAmount,
-      boostLevel: getBoostLevel(defaultBoostValue) || 0,
-    }
+    // this.state = { selectedBoostAmountUsd: 0 }
 
     this.onChange = this.onChange.bind(this)
   }
@@ -28,7 +22,7 @@ class BoostSlider extends Component {
   async componentDidMount() {
     $('[data-toggle="tooltip"]').tooltip()
 
-    this.onChange(this.state.selectedBoostAmount)
+    this.onChange(this.props.selectedBoostAmount)
   }
 
   componentWillUnmount() {
@@ -36,13 +30,8 @@ class BoostSlider extends Component {
   }
 
   async onChange(value) {
-    const boostLevel = getBoostLevel(value)
-    this.setState({
-      selectedBoostAmount: value,
-      boostLevel
-    })
-    const disableNextBtn = value > this.state.allowanceRemaining || value > this.props.ognBalance
-    this.props.onChange(value, boostLevel, disableNextBtn)
+    const disableNextBtn = value > this.props.ognBalance
+    this.props.onChange(value, getBoostLevel(value), disableNextBtn)
     // const selectedBoostAmountUsd = await getFiatPrice(value, 'USD')
     // this.setState({
     //   selectedBoostAmountUsd
@@ -51,6 +40,7 @@ class BoostSlider extends Component {
 
   render() {
     const { ognBalance } = this.props
+    const boostLevel = getBoostLevel(this.props.selectedBoostAmount)
 
     return (
       <div className="boost-slider">
@@ -70,34 +60,34 @@ class BoostSlider extends Component {
             </div>`
           } />
         <div className="level-container">
-          <span className={`boosted badge ${this.state.boostLevel.toLowerCase()}`}>
+          <span className={`boosted badge ${boostLevel.toLowerCase()}`}>
             <img src="images/boost-icon-arrow.svg" role="presentation" />
           </span>
-          { this.state.boostLevel }
-          { this.state.boostLevel.match(/medium/i) && ' (recommended)'}
+          { boostLevel }
+          { boostLevel.match(/medium/i) && ' (recommended)'}
           <div className="amount-container">
             <p>
               <img src="images/ogn-icon.svg" role="presentation" />
-              { this.state.selectedBoostAmount }&nbsp;
+              { this.props.selectedBoostAmount }&nbsp;
               <a href="#" target="_blank" rel="noopener noreferrer">OGN</a>
               {/* <span className="help-block"> | { this.state.selectedBoostAmountUsd } USD</span> */}
             </p>
           </div>
         </div>
         <Slider
-          className={ `boost-level-${this.state.boostLevel}` }
+          className={ `boost-level-${boostLevel}` }
           onChange={ this.onChange }
-          defaultValue={ this.state.selectedBoostAmount }
+          defaultValue={ this.props.selectedBoostAmount }
           min={ minBoostValue }
           disabled={!ognBalance}
           max={ maxBoostValue } />
-        <p className="text-italics">{ boostLevels[this.state.boostLevel].desc }</p>
+        <p className="text-italics">{ boostLevels[boostLevel].desc }</p>
         {ognBalance === 0 &&
           <div className="info-box">
             <p>You have 0 <a href="#" target="_blank" rel="noopener noreferrer">OGN</a> in your wallet and cannot boost.</p>
           </div>
         }
-        {ognBalance > 0 && ognBalance < this.state.selectedBoostAmount &&
+        {ognBalance > 0 && ognBalance < this.props.selectedBoostAmount &&
           <div className="info-box warn">
             <p>You don’t have enough OGN in your wallet.</p>
             <a

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -56,6 +56,7 @@ class ListingCreate extends Component {
 
     this.state = {
       step: this.STEP.PICK_SCHEMA,
+      selectedBoostAmount: props.wallet.ognBalance ? defaultBoostValue : 0,
       selectedSchemaType: null,
       selectedSchema: null,
       translatedSchema: null,
@@ -93,10 +94,19 @@ class ListingCreate extends Component {
     this.updateUsdPrice = this.updateUsdPrice.bind(this)
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     // conditionally show boost tutorial
     if (!this.state.showBoostTutorial) {
       this.detectNeedForBoostTutorial()
+    }
+
+    const { ognBalance } = this.props.wallet
+    // apply OGN detection to slider
+    if (ognBalance !== prevProps.wallet.ognBalance) {
+      // only if prior to boost selection step
+      this.state.step < this.STEP.BOOST && this.setState({
+        selectedBoostAmount: ognBalance ? defaultBoostValue : 0
+      })
     }
   }
 
@@ -253,7 +263,8 @@ class ListingCreate extends Component {
           boostValue,
           boostLevel
         }
-      }
+      },
+      selectedBoostAmount: boostValue
     })
   }
 
@@ -294,6 +305,7 @@ class ListingCreate extends Component {
         ...transactionReceipt,
         transactionTypeKey: 'createListing'
       })
+      this.props.getOgnBalance()
       this.setState({ step: this.STEP.SUCCESS })
     } catch (error) {
       console.error(error)
@@ -321,6 +333,7 @@ class ListingCreate extends Component {
       currentProvider,
       formListing,
       isBoostExpanded,
+      selectedBoostAmount,
       selectedSchema,
       selectedSchemaType,
       schemaExamples,
@@ -497,6 +510,7 @@ class ListingCreate extends Component {
                   <BoostSlider
                     onChange={ this.setBoost }
                     ognBalance={ wallet.ognBalance }
+                    selectedBoostAmount={ selectedBoostAmount }
                   />
                 }
                 <div className="btn-container">


### PR DESCRIPTION
This allows a seller to go backward from step 4️⃣ to 3️⃣ and maintain the selected boost level. It also reactively updates the wallet balance after the boosted listing is created.