### PR TITLE
resize btns according to design spec and to prevent overlap

### DIFF
--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -604,7 +604,7 @@ class ListingCreate extends Component {
                           role="presentation"
                         />
                         <span className="text-bold">
-                          {formData.price}
+                          {Number(formData.price).toLocaleString(undefined, { minimumFractionDigits: 5, maximumFractionDigits: 5 })}
                         </span>&nbsp;
                         <a
                           className="eth-abbrev"

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -396,7 +396,7 @@ class ListingCreate extends Component {
                 </div>
                 <div className="btn-container">
                   <button
-                    className="float-right btn btn-primary"
+                    className="float-right btn btn-primary btn-listing-create"
                     onClick={() => this.goToDetailsStep()}
                   >
                     <FormattedMessage
@@ -436,7 +436,7 @@ class ListingCreate extends Component {
                   <div className="btn-container">
                     <button
                       type="button"
-                      className="btn btn-other"
+                      className="btn btn-other btn-listing-create"
                       onClick={() =>
                         this.setState({ step: this.STEP.PICK_SCHEMA })
                       }
@@ -448,7 +448,7 @@ class ListingCreate extends Component {
                     </button>
                     <button
                       type="submit"
-                      className="float-right btn btn-primary"
+                      className="float-right btn btn-primary btn-listing-create"
                     >
                       <FormattedMessage
                         id={'continueButtonLabel'}

--- a/src/components/listings-grid.js
+++ b/src/components/listings-grid.js
@@ -13,8 +13,6 @@ import { LISTINGS_PER_PAGE } from 'components/constants'
 class ListingsGrid extends Component {
   constructor(props) {
     super(props)
-    this.state = {
-    }
 
     this.handleOnChange = this.handleOnChange.bind(this)
   }

--- a/src/components/my-sale-card.js
+++ b/src/components/my-sale-card.js
@@ -96,9 +96,8 @@ class MySaleCard extends Component {
                 <p className="price">
                   <FormattedMessage
                     id={'my-sale-card.price'}
-                    defaultMessage={'Price: {price}'}
-                    values={{ price }}
-                  />
+                    defaultMessage={'Price'}
+                  />:&nbsp;{Number(price).toLocaleString(undefined, { minimumFractionDigits: 5, maximumFractionDigits: 5 })}
                 </p>
                 {/* Not Yet Relevant */}
                 {/*<p className="quantity">Quantity: {quantity.toLocaleString()}</p>*/}

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1393,6 +1393,7 @@ a:hover {
 
 .btn-container {
   padding-top: 1rem;
+  padding-bottom: 1rem;
 }
 
 .btn {
@@ -2882,6 +2883,11 @@ select.form-control:not([size]):not([multiple]) {
 
 .text-bold {
   font-weight: bold;
+}
+
+.btn-listing-create {
+  width: 156px;
+  margin-bottom: 1rem;
 }
 
 /* OGN Balance Tooltip */

--- a/translations/all-messages.json
+++ b/translations/all-messages.json
@@ -175,7 +175,7 @@
   "my-sale-card.ethereumCurrencyAbbrev": "ETH",
   "my-sale-card.unnamedUser": "Unnamed User",
   "my-sale-card.buyerNameLink": "sold to {linkToBuyer}",
-  "my-sale-card.price": "Price: {price}",
+  "my-sale-card.price": "Price",
   "my-sale-card.nextStep1": "{nextStep} Send the order to buyer",
   "my-sale-card.nextStep2": "{nextStep} Wait for buyer to receive order",
   "my-sale-card.nextStep3": "{nextStep} Withdraw funds",

--- a/translations/messages/src/components/my-sale-card.json
+++ b/translations/messages/src/components/my-sale-card.json
@@ -13,7 +13,7 @@
   },
   {
     "id": "my-sale-card.price",
-    "defaultMessage": "Price: {price}"
+    "defaultMessage": "Price"
   },
   {
     "id": "my-sale-card.nextStep1",


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)~~

### Description:

Buttons on create listing page were touching on smaller screens. Resized them to match the UI mockup and maintain spacing on smaller screen sizes. 

https://app.zeplin.io/project/59fa2311bac7acbc8d953da9/screen/5b7538b2636eb55062e63a77
