### PR TITLE
set OGN links to token page

### DIFF
--- a/src/components/boost-slider.js
+++ b/src/components/boost-slider.js
@@ -56,7 +56,7 @@ class BoostSlider extends Component {
           title={
             `<div class="boost-tooltip">
               <p>A boost increases the visibility of your listing and also works as a guarantee in case something goes wrong.</p>
-              <a href="#" target="_blank" rel="noopener noreferrer">Learn More</a>
+              <a href="/#/about-tokens" target="_blank" rel="noopener noreferrer">Learn More</a>
             </div>`
           } />
         <div className="level-container">
@@ -69,7 +69,7 @@ class BoostSlider extends Component {
             <p>
               <img src="images/ogn-icon.svg" role="presentation" />
               { this.props.selectedBoostAmount }&nbsp;
-              <a href="#" target="_blank" rel="noopener noreferrer">OGN</a>
+              <a href="/#/about-tokens" target="_blank" rel="noopener noreferrer">OGN</a>
               {/* <span className="help-block"> | { this.state.selectedBoostAmountUsd } USD</span> */}
             </p>
           </div>
@@ -84,7 +84,7 @@ class BoostSlider extends Component {
         <p className="text-italics">{ boostLevels[boostLevel].desc }</p>
         {ognBalance === 0 &&
           <div className="info-box">
-            <p>You have 0 <a href="#" target="_blank" rel="noopener noreferrer">OGN</a> in your wallet and cannot boost.</p>
+          <p>You have 0 <a href="/#/about-tokens" target="_blank" rel="noopener noreferrer">OGN</a> in your wallet and cannot boost.</p>
           </div>
         }
         {ognBalance > 0 && ognBalance < this.props.selectedBoostAmount &&
@@ -103,10 +103,10 @@ class BoostSlider extends Component {
         }
         <p className="help-block bottom-explainer">
           Boosts are always calculated and charged in&nbsp;
-          <a href="#" target="_blank" rel="noopener noreferrer">
+          <a href="/#/about-tokens" target="_blank" rel="noopener noreferrer">
             OGN
           </a>.&nbsp;
-          <a href="#" target="_blank" rel="noopener noreferrer">
+          <a href="/#/about-tokens" target="_blank" rel="noopener noreferrer">
             Learn more &#x25b8;
           </a>
         </p>

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -475,7 +475,7 @@ class ListingCreate extends Component {
                 {showBoostTutorial &&
                   <div className="info-box">
                     <img src="images/ogn-icon-horiz.svg" role="presentation" />
-                    <p className="text-bold">You have 0 <a href="#" target="_blank" rel="noopener noreferrer">OGN</a> in your wallet.</p>
+                  <p className="text-bold">You have 0 <a href="/#/about-tokens" target="_blank" rel="noopener noreferrer">OGN</a> in your wallet.</p>
                     <p>Once you acquire some OGN you will be able to boost your listing.</p>
                     <p className="expand-btn" onClick={ this.toggleBoostBox }>
                       What is a boost? <span className={ isBoostExpanded ? 'rotate-up' : '' }>&#x25be;</span>
@@ -501,7 +501,7 @@ class ListingCreate extends Component {
                         </p>
                         <p>
                           Boosting on the Origin DApp is done using{' '}
-                          <a href="#" arget="_blank" rel="noopener noreferrer">
+                          <a href="/#/about-tokens" target="_blank" rel="noopener noreferrer">
                             Origin Tokens (OGN).
                           </a>
                         </p>
@@ -642,7 +642,7 @@ class ListingCreate extends Component {
                         </span>&nbsp;
                         <a
                           className="ogn-abbrev"
-                          href="#"
+                          href="/#/about-tokens"
                           target="_blank"
                           rel="noopener noreferrer"
                         >

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -475,7 +475,7 @@ class ListingCreate extends Component {
                 {showBoostTutorial &&
                   <div className="info-box">
                     <img src="images/ogn-icon-horiz.svg" role="presentation" />
-                  <p className="text-bold">You have 0 <a href="/#/about-tokens" target="_blank" rel="noopener noreferrer">OGN</a> in your wallet.</p>
+                    <p className="text-bold">You have 0 <a href="/#/about-tokens" target="_blank" rel="noopener noreferrer">OGN</a> in your wallet.</p>
                     <p>Once you acquire some OGN you will be able to boost your listing.</p>
                     <p className="expand-btn" onClick={ this.toggleBoostBox }>
                       What is a boost? <span className={ isBoostExpanded ? 'rotate-up' : '' }>&#x25be;</span>


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)~~

### Description:

OGN/Boost anchor tags within the create listing and boost UI were directing to the home page. I set them to direct to the "About Origin Token Page".
