### PR TITLE
Fixing bugs in listing type selection when creating listing

### DIFF
--- a/public/schemas/announcements.json
+++ b/public/schemas/announcements.json
@@ -48,7 +48,7 @@
     },
     "price": {
       "type": "number",
-      "title": "schema.announcements.price",
+      "title": "schema.announcements.priceInETH",
       "default": 0,
       "enum": [
         0

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -62,6 +62,7 @@ class ListingCreate extends Component {
       translatedSchema: null,
       schemaExamples: null,
       schemaFetched: false,
+      showNoSchemaSelectedError: false,
       formListing: {
         formData: {
           boostValue: defaultBoostValue,
@@ -176,6 +177,7 @@ class ListingCreate extends Component {
           selectedSchemaType,
           selectedSchema: schemaJson,
           schemaFetched: true,
+          showNoSchemaSelectedError: false,
           translatedSchema,
           schemaExamples:
             translatedSchema &&
@@ -193,7 +195,9 @@ class ListingCreate extends Component {
       })
       window.scrollTo(0, 0)
     } else {
-      console.error('Error fetching schema JSON')
+      this.setState({
+        showNoSchemaSelectedError: true
+      })
     }
   }
 
@@ -340,6 +344,7 @@ class ListingCreate extends Component {
       selectedSchema,
       selectedSchemaType,
       schemaExamples,
+      showNoSchemaSelectedError,
       step,
       translatedSchema,
       usdListingPrice,
@@ -396,6 +401,16 @@ class ListingCreate extends Component {
                       </div>
                     </div>
                   ))}
+                  {showNoSchemaSelectedError &&
+                    <div className="info-box warn">
+                      <p>
+                        <FormattedMessage
+                          id={'listing-create.noSchemaSelectedError'}
+                          defaultMessage={'You must first select a listing type'}
+                        />
+                      </p>
+                    </div>
+                  }
                 </div>
                 <div className="btn-container">
                   <button

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -2765,7 +2765,8 @@ select.form-control:not([size]):not([multiple]) {
   padding: 15px;
 }
 
-.listing-form .select-boost .boost-slider .info-box {
+.listing-form .select-boost .boost-slider .info-box,
+.listing-form .schema-options .info-box {
   padding: 10px;
   margin-top: 20px;
   margin-bottom: 10px;
@@ -2775,13 +2776,17 @@ select.form-control:not([size]):not([multiple]) {
   margin: 10px 0 5px;
 }
 
-.boost-slider .info-box.warn {
+.listing-form .info-box.warn {
   background-color: var(--orange-red-light);
   border: 1px solid var(--orange-red);
 }
 
-.boost-slider .info-box.warn p {
+.listing-form .info-box.warn p {
   color: var(--orange-red);
+}
+
+.listing-form .schema-options .info-box p {
+  margin-bottom: 0;
 }
 
 .boost-tooltip {

--- a/translations/all-messages.json
+++ b/translations/all-messages.json
@@ -75,6 +75,7 @@
   "listing-create.navigationWarning": "Are you sure you want to leave? If you leave this page your progress will be lost.",
   "listing-create.stepNumberLabel": "STEP {stepNumber}",
   "listing-create.whatTypeOfListing": "What type of listing do you want to create?",
+  "listing-create.noSchemaSelectedError": "You must first select a listing type",
   "listing-create.next": "Next",
   "listing-create.createListingHeading": "Create your listing",
   "backButtonLabel": "Back",

--- a/translations/messages/src/components/listing-create.json
+++ b/translations/messages/src/components/listing-create.json
@@ -12,6 +12,10 @@
     "defaultMessage": "What type of listing do you want to create?"
   },
   {
+    "id": "listing-create.noSchemaSelectedError",
+    "defaultMessage": "You must first select a listing type"
+  },
+  {
     "id": "listing-create.next",
     "defaultMessage": "Next"
   },


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any new text/strings for translation

### Description:
- Fixes for https://github.com/OriginProtocol/origin-dapp/issues/495 and https://github.com/OriginProtocol/origin-dapp/issues/492
- Adds error message if user tries to go to "next" step without selecting a listing type
- Fixes incorrect message ID in announcements listing



<img width="563" alt="screenshot 2018-09-22 23 50 58" src="https://user-images.githubusercontent.com/5402813/45924683-8be8f380-bec3-11e8-94fe-c35efc9929b9.png">
