### PR TITLE
Wire up "enable messaging" button in arbitration process

### DIFF
--- a/src/components/dropdowns/messages.js
+++ b/src/components/dropdowns/messages.js
@@ -5,8 +5,7 @@ import { withRouter } from 'react-router'
 import { Link } from 'react-router-dom'
 import $ from 'jquery'
 
-import { dismissMessaging, enableMessaging } from 'actions/App'
-import { storeWeb3Intent } from 'actions/App'
+import { dismissMessaging, enableMessaging, storeWeb3Intent } from 'actions/App'
 
 import ConversationListItem from 'components/conversation-list-item'
 


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything

### Description:

- This works, but it isn't ideal
- It would be nice if the `startConversing()` method accepted a confirmation callback and/or returned a promise. This would prevent the need to do the polling that I'm doing here to know if messaging has been enabled so the user can proceed with the arbitration process.
