### PR TITLE
Show dispute transactions on purchases/offers.

### DIFF
--- a/src/components/purchase-detail.js
+++ b/src/components/purchase-detail.js
@@ -164,6 +164,14 @@ class PurchaseDetail extends Component {
         id: 'purchase-detail.offerAccepted',
         defaultMessage: 'Offer Accepted'
       },
+      offerDisputed: {
+        id: 'purchase-detail.offerDisputed',
+        defaultMessage: 'Dispute Started'
+      },
+      offerRuling: {
+        id: 'purchase-detail.offerRuling',
+        defaultMessage: 'Ruling Complete'
+      },
       saleCompleted: {
         id: 'purchase-detail.saleCompleted',
         defaultMessage: 'Sale Completed'
@@ -681,6 +689,8 @@ class PurchaseDetail extends Component {
     const offerCreated = purchase.event('OfferCreated')
     const offerWithdrawn = purchase.event('OfferWithdrawn')
     const offerAccepted = purchase.event('OfferAccepted')
+    const offerDisputed = purchase.event('OfferDisputed')
+    const offerRuling = purchase.event('OfferRuling')
     const offerFinalized = purchase.event('OfferFinalized')
     const offerData = purchase.event('OfferData')
 
@@ -1099,6 +1109,14 @@ class PurchaseDetail extends Component {
                     transaction={offerAccepted}
                     buyer={buyer}
                     seller={seller}
+                  />
+                  <TransactionEvent
+                    eventName={this.props.intl.formatMessage(this.intlMessages.offerDisputed)}
+                    transaction={offerDisputed}
+                  />
+                  <TransactionEvent
+                    eventName={this.props.intl.formatMessage(this.intlMessages.offerRuling)}
+                    transaction={offerRuling}
                   />
                   <TransactionEvent
                     eventName={this.props.intl.formatMessage(this.intlMessages.saleCompleted)}

--- a/src/pages/purchases/transaction-event.js
+++ b/src/pages/purchases/transaction-event.js
@@ -20,10 +20,10 @@ class TransactionEvent extends Component {
           {transaction && <EtherscanLink hash={transaction.transactionHash} />}
         </td>
         <td className="text-truncate">
-          {buyer.address && <EtherscanLink hash={buyer.address} />}
+          {buyer && buyer.address && <EtherscanLink hash={buyer.address} />}
         </td>
         <td className="text-truncate">
-          {seller.address && <EtherscanLink hash={seller.address} />}
+          {seller && seller.address && <EtherscanLink hash={seller.address} />}
         </td>
       </tr>
     )

--- a/translations/all-messages.json
+++ b/translations/all-messages.json
@@ -233,6 +233,8 @@
   "purchase-detail.offerMade": "Offer Made",
   "purchase-detail.offerWithdrawn": "Offer Withdrawn",
   "purchase-detail.offerAccepted": "Offer Accepted",
+  "purchase-detail.offerDisputed": "Dispute Started",
+  "purchase-detail.offerRuling": "Ruling Complete",
   "purchase-detail.saleCompleted": "Sale Completed",
   "purchase-detail.saleReviewed": "Sale Reviewed",
   "purchase-detail.unnamedUser": "Unnamed User",

--- a/translations/messages/src/components/purchase-detail.json
+++ b/translations/messages/src/components/purchase-detail.json
@@ -88,6 +88,14 @@
     "defaultMessage": "Offer Accepted"
   },
   {
+    "id": "purchase-detail.offerDisputed",
+    "defaultMessage": "Dispute Started"
+  },
+  {
+    "id": "purchase-detail.offerRuling",
+    "defaultMessage": "Ruling Complete"
+  },
+  {
     "id": "purchase-detail.saleCompleted",
     "defaultMessage": "Sale Completed"
   },


### PR DESCRIPTION
Currently, dispute transactions are not shown on the list of transactions. This is confusing when a purchase is in dispute, since there is no trace of it in the transactions.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any new text/strings for translation