### PR TITLE
Fix display of transaction from addresses on offer page.

### DIFF
--- a/src/components/arbitration.js
+++ b/src/components/arbitration.js
@@ -225,33 +225,24 @@ class Arbitration extends Component {
                     <th scope="col" style={{ width: '200px' }}>TxName</th>
                     <th scope="col">TxHash</th>
                     <th scope="col">From</th>
-                    <th scope="col">To</th>
                   </tr>
                 </thead>
                 <tbody>
                   <TransactionEvent
                     eventName="Payment received"
-                    transaction={paymentEvent}
-                    buyer={buyer}
-                    seller={seller}
+                    event={paymentEvent}
                   />
                   <TransactionEvent
                     eventName="Sent by seller"
-                    transaction={fulfillmentEvent}
-                    buyer={buyer}
-                    seller={seller}
+                    event={fulfillmentEvent}
                   />
                   <TransactionEvent
                     eventName="Received by buyer"
-                    transaction={receiptEvent}
-                    buyer={buyer}
-                    seller={seller}
+                    event={receiptEvent}
                   />
                   <TransactionEvent
                     eventName="Seller reviewed"
-                    transaction={withdrawalEvent}
-                    buyer={buyer}
-                    seller={seller}
+                    event={withdrawalEvent}
                   />
                 </tbody>
               </table>

--- a/src/components/purchase-detail.js
+++ b/src/components/purchase-detail.js
@@ -1074,52 +1074,39 @@ class PurchaseDetail extends Component {
                         defaultMessage={'From'}
                       />
                     </th>
-                    <th scope="col">
-                      <FormattedMessage
-                        id={'purchase-detail.to'}
-                        defaultMessage={'To'}
-                      />
-                    </th>
                   </tr>
                 </thead>
                 <tbody>
                   <TransactionEvent
                     eventName={this.props.intl.formatMessage(this.intlMessages.offerMade)}
-                    transaction={offerCreated}
-                    buyer={buyer}
-                    seller={seller}
+                    event={offerCreated}
+                    from={buyer}
                   />
                   <TransactionEvent
                     eventName={this.props.intl.formatMessage(this.intlMessages.offerWithdrawn)}
-                    transaction={offerWithdrawn}
-                    buyer={buyer}
-                    seller={seller}
+                    event={offerWithdrawn}
+                    from={buyer}
                   />
                   <TransactionEvent
                     eventName={this.props.intl.formatMessage(this.intlMessages.offerAccepted)}
-                    transaction={offerAccepted}
-                    buyer={buyer}
-                    seller={seller}
+                    event={offerAccepted}
+                    from={seller}
                   />
                   <TransactionEvent
                     eventName={this.props.intl.formatMessage(this.intlMessages.offerDisputed)}
-                    transaction={offerDisputed}
+                    event={offerDisputed}
                   />
                   <TransactionEvent
                     eventName={this.props.intl.formatMessage(this.intlMessages.offerRuling)}
-                    transaction={offerRuling}
+                    event={offerRuling}
                   />
                   <TransactionEvent
                     eventName={this.props.intl.formatMessage(this.intlMessages.saleCompleted)}
-                    transaction={offerFinalized}
-                    buyer={buyer}
-                    seller={seller}
+                    event={offerFinalized}
                   />
                   <TransactionEvent
                     eventName={this.props.intl.formatMessage(this.intlMessages.saleReviewed)}
-                    transaction={offerData}
-                    buyer={buyer}
-                    seller={seller}
+                    event={offerData}
                   />
                 </tbody>
               </table>

--- a/src/pages/purchases/transaction-event.js
+++ b/src/pages/purchases/transaction-event.js
@@ -4,20 +4,19 @@ import EtherscanLink from 'components/etherscan-link'
 import origin from '../../services/origin'
 
 class TransactionEvent extends Component {
-  async componentDidMount(){
-    const {event} = this.props
-    
+  async componentDidMount() {
+    const { event } = this.props
+
     if (!event) {
       return null
     }
 
-    // If no from address is passed in, we load the origin address from 
+    // If no from address is passed in, we load the origin address from
     // transaction the event was fired from
-    if(this.props.from === undefined){
+    if (this.props.from === undefined) {
       const txHash = event.transactionHash
       const transaction = await origin.contractService.getTransaction(txHash)
-      this.setState({transactionFrom: {address: transaction.from}})
-      console.log("MAOSN", transaction)
+      this.setState({ transactionFrom: { address: transaction.from } })
     }
   }
 

--- a/src/pages/purchases/transaction-event.js
+++ b/src/pages/purchases/transaction-event.js
@@ -1,12 +1,31 @@
 import React, { Component } from 'react'
 
 import EtherscanLink from 'components/etherscan-link'
+import origin from '../../services/origin'
 
 class TransactionEvent extends Component {
-  render() {
-    const { eventName, transaction, buyer, seller } = this.props
+  async componentDidMount(){
+    const {event} = this.props
+    
+    if (!event) {
+      return null
+    }
 
-    if (!transaction) {
+    // If no from address is passed in, we load the origin address from 
+    // transaction the event was fired from
+    if(this.props.from === undefined){
+      const txHash = event.transactionHash
+      const transaction = await origin.contractService.getTransaction(txHash)
+      this.setState({transactionFrom: {address: transaction.from}})
+      console.log("MAOSN", transaction)
+    }
+  }
+
+  render() {
+    const { eventName, event } = this.props
+    const from = this.props.from || (this.state && this.state.transactionFrom)
+
+    if (!event) {
       return null
     }
 
@@ -17,13 +36,10 @@ class TransactionEvent extends Component {
           {eventName}
         </td>
         <td className="text-truncate">
-          {transaction && <EtherscanLink hash={transaction.transactionHash} />}
+          {event && <EtherscanLink hash={event.transactionHash} />}
         </td>
         <td className="text-truncate">
-          {buyer && buyer.address && <EtherscanLink hash={buyer.address} />}
-        </td>
-        <td className="text-truncate">
-          {seller && seller.address && <EtherscanLink hash={seller.address} />}
+          {from && from.address && <EtherscanLink hash={from.address} />}
         </td>
       </tr>
     )

--- a/translations/all-messages.json
+++ b/translations/all-messages.json
@@ -259,7 +259,6 @@
   "purchase-detail.txName": "TxName",
   "purchase-detail.txHash": "TxHash",
   "purchase-detail.from": "From",
-  "purchase-detail.to": "To",
   "purchase-detail.listingDetails": "Listing Details",
   "purchase-detail.viewOnIPFS": "View on IPFS",
   "purchase-detail.reviewsHeading": "Reviews",

--- a/translations/messages/src/components/purchase-detail.json
+++ b/translations/messages/src/components/purchase-detail.json
@@ -180,10 +180,6 @@
     "defaultMessage": "From"
   },
   {
-    "id": "purchase-detail.to",
-    "defaultMessage": "To"
-  },
-  {
     "id": "purchase-detail.listingDetails",
     "defaultMessage": "Listing Details"
   },


### PR DESCRIPTION
- PurchaseDetails -  Transactions now show the correct from address
- TransactionEvent - Refactored “transaction” to “event” inside the component, since it’s an event
- TransactionEvent - Now loads the transaction origin address if no from address is passed in
- Arbitration - Updated to use new props for TransactionEvent. The event display looks out of date, so I didn’t adjust things further.

@micahalcorn I didn't test the arbitration page, since I'm not sure how to get it going. Feel free to make any other changes you want to the offer page from here.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any new text/strings for translation
