### PR TITLE
Set origin-js affiliate/arbitrator from env vars

### DIFF
--- a/src/services/origin.js
+++ b/src/services/origin.js
@@ -69,6 +69,8 @@ const config = {
   ipfsGatewayProtocol: process.env.IPFS_GATEWAY_PROTOCOL,
   discoveryServerUrl: process.env.DISCOVERY_SERVER_URL,
   messagingNamespace: process.env.MESSAGING_NAMESPACE,
+  arbitrator: process.env.ARBITRATOR_ACCOUNT,
+  affiliate: process.env.AFFILIATE_ACCOUNT,
   attestationServerUrl,
   ipfsCreator,
   OrbitDB,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const isProduction = process.env.NODE_ENV === 'production'
 
 const env = {
   ARBITRATOR_ACCOUNT: '',
+  AFFILIATE_ACCOUNT: '',
   BRIDGE_SERVER_DOMAIN: '',
   BRIDGE_SERVER_PROTOCOL: 'https',
   CONTRACT_ADDRESSES: '{}',


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any new text/strings for translation
- [x] Map any new environment variables with a default value in the Webpack config
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:

Didn't have time to test this yet - @micahalcorn can you check that this works with https://github.com/OriginProtocol/origin-js/pull/549 ? Just need to make sure that offers can still be created and viewed in the Dapp. 🙏 