### PR TITLE
add create profile type transaction to display in transactions dropdown

### DIFF
--- a/src/actions/Profile.js
+++ b/src/actions/Profile.js
@@ -67,7 +67,12 @@ export function deployProfile() {
       attestations: [],
       options: {
         transactionHashCallback: hash => {
-          dispatch(upsertTransaction({ transactionHash: hash }))
+          dispatch(upsertTransaction({
+            transactionHash: hash,
+            transactionTypeKey: 'updateProfile',
+            timestamp: Date.now() / 1000,
+            confirmationCount: 0
+          }))
           dispatch({
             type: ProfileConstants.DEPLOY_IN_PROGRESS,
             hash

--- a/src/components/transaction-message.js
+++ b/src/components/transaction-message.js
@@ -40,6 +40,10 @@ class TransactionMessage extends Component {
       reviewSale: {
         id: 'transaction.reviewSale',
         defaultMessage: 'You left a review.'
+      },
+      updateProfile: {
+        id: 'transaction.updateProfile',
+        defaultMessage: 'You updated your profile.'
       }
     })
   }

--- a/src/components/transaction.js
+++ b/src/components/transaction.js
@@ -32,6 +32,7 @@ class Transaction extends Component {
   }
 
   render() {
+    const transactionTypeKeysWithoutListing = ['updateProfile']
     const { confirmationCompletionCount, transaction } = this.props
     const { listing } = this.state
     const {
@@ -42,7 +43,7 @@ class Transaction extends Component {
     } = transaction
     const created = timestamp
 
-    if (!listing) {
+    if (!listing && !transactionTypeKeysWithoutListing.includes(transactionTypeKey)) {
       return null
     }
 

--- a/translations/all-messages.json
+++ b/translations/all-messages.json
@@ -332,6 +332,7 @@
   "transaction.createListing": "You created a listing.",
   "transaction.initiateDispute": "You initiated a dispute.",
   "transaction.reviewSale": "You left a review.",
+  "transaction.updateProfile": "You updated your profile.",
   "transaction-progress.purchased": "Purchased",
   "transaction-progress.sentBySeller": "Sent by seller",
   "transaction-progress.receivedByMe": "Received by me",

--- a/translations/messages/src/components/transaction-message.json
+++ b/translations/messages/src/components/transaction-message.json
@@ -30,5 +30,9 @@
   {
     "id": "transaction.reviewSale",
     "defaultMessage": "You left a review."
+  },
+  {
+    "id": "transaction.updateProfile",
+    "defaultMessage": "You updated your profile."
   }
 ]


### PR DESCRIPTION
### Description:
When publishing profile changes transaction now displays in transaction dropdown. Previously it just showed 1 pending transaction but no details about that transaction. 

**Solves Issue:** https://github.com/OriginProtocol/origin-dapp/pull/617#issuecomment-425566987

<img width="817" alt="screenshot 2018-09-29 00 31 55" src="https://user-images.githubusercontent.com/579910/46236465-314a0e80-c37f-11e8-82ff-6c730ea3e4cc.png">