### PR TITLE
Hide create listing form error summary

### DIFF
--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -64,6 +64,7 @@ class ListingCreate extends Component {
           boostLevel: getBoostLevel(defaultBoostValue)
         }
       },
+      showDetailsFormErrorMsg: false,
       showBoostTutorial: false
     }
 
@@ -193,7 +194,8 @@ class ListingCreate extends Component {
           ...formListing.formData
         }
       },
-      step: this.STEP.BOOST
+      step: this.STEP.BOOST,
+      showDetailsFormErrorMsg: false
     })
     window.scrollTo(0, 0)
     this.checkOgnBalance()
@@ -285,6 +287,7 @@ class ListingCreate extends Component {
       showNoSchemaSelectedError,
       step,
       translatedSchema,
+      showDetailsFormErrorMsg,
       showBoostTutorial
     } = this.state
     const { formData } = formListing
@@ -392,13 +395,19 @@ class ListingCreate extends Component {
                   schema={translatedSchema}
                   onSubmit={this.onDetailsEntered}
                   formData={formListing.formData}
-                  onError={errors =>
-                    console.log(
-                      `react-jsonschema-form errors: ${errors.length}`
-                    )
-                  }
+                  onError={() => this.setState({ showDetailsFormErrorMsg: true })}
                   uiSchema={this.uiSchema}
                 >
+                  {showDetailsFormErrorMsg &&
+                    <div className="info-box warn">
+                      <p>
+                        <FormattedMessage
+                          id={'listing-create.showDetailsFormErrorMsg'}
+                          defaultMessage={'Please fix errors before continuing.'}
+                        />
+                      </p>
+                    </div>
+                  }
                   <div className="btn-container">
                     <button
                       type="button"

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -2420,6 +2420,11 @@ textarea:-moz-ui-invalid {
   margin-top: 0;
 }
 
+/* hide form error summary in react-jsonschema-forms */
+.rjsf .errors {
+  display: none;
+}
+
 .form-control,
 select.form-control:not([size]):not([multiple]) {
   height: 46px;
@@ -2872,7 +2877,8 @@ select.form-control:not([size]):not([multiple]) {
 }
 
 .listing-form .schema-options .info-box p,
-.listing-form .photo-picker .info-box p {
+.listing-form .photo-picker .info-box p,
+.listing-form .schema-details .info-box p {
   margin-bottom: 0;
 }
 

--- a/translations/all-messages.json
+++ b/translations/all-messages.json
@@ -95,6 +95,7 @@
   "listing-create.noSchemaSelectedError": "You must first select a listing type",
   "listing-create.next": "Next",
   "listing-create.createListingHeading": "Create your listing",
+  "listing-create.showDetailsFormErrorMsg": "Please fix errors before continuing.",
   "backButtonLabel": "Back",
   "continueButtonLabel": "Continue",
   "listing-create.reviewListingHeading": "Review your listing",

--- a/translations/messages/src/components/listing-create.json
+++ b/translations/messages/src/components/listing-create.json
@@ -28,6 +28,10 @@
     "defaultMessage": "Create your listing"
   },
   {
+    "id": "listing-create.showDetailsFormErrorMsg",
+    "defaultMessage": "Please fix errors before continuing."
+  },
+  {
     "id": "backButtonLabel",
     "defaultMessage": "Back"
   },


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any new text/strings for translation

### Description:

I don't see a way to prevent the error from being shown by `react-jsonschema-form` programmatically, so I did it with CSS.

I also added a warning message because the form didn't notify you when an error occurred, so you'd click "continue" and nothing would happen. The UX wasn't so bad before because the showing of the error summary caused the page to jump down and the error text came into view.

Here's the new warning message:
<img width="590" alt="screenshot 2018-09-30 23 42 55" src="https://user-images.githubusercontent.com/5402813/46271699-042a6700-c50b-11e8-9fc4-1b4d68b276be.png">


Issue: https://github.com/OriginProtocol/origin-dapp/issues/623
