### PR TITLE
Render new lines in descriptions

### DIFF
--- a/src/components/arbitration.js
+++ b/src/components/arbitration.js
@@ -250,7 +250,7 @@ class Arbitration extends Component {
                     <h1 className="title text-truncate placehold">
                       {listing.name}
                     </h1>
-                    <p className="description placehold">
+                    <p className="ws-aware description placehold">
                       {listing.description}
                     </p>
                   </div>

--- a/src/components/listing-create.js
+++ b/src/components/listing-create.js
@@ -582,7 +582,7 @@ class ListingCreate extends Component {
                       </p>
                     </div>
                     <div className="col-md-9">
-                      <p>{formData.description}</p>
+                      <p className="ws-aware">{formData.description}</p>
                     </div>
                   </div>
                   <div className="row">

--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -422,16 +422,8 @@ class ListingsDetail extends Component {
                 )}
               </div>
               <h1 className="title text-truncate placehold">{name}</h1>
-              <p className="description placehold">
-                {description &&
-                  description.split('\n').map((item, key) => {
-                    return (
-                      <Fragment key={key}>
-                        {item}
-                        <br />
-                      </Fragment>
-                    )
-                  })}
+              <p className="ws-aware description placehold">
+                {description}
               </p>
               {/* Via Stan 5/25/2018: Hide until contracts allow for unitsRemaining > 1 */}
               {/*!!unitsRemaining && unitsRemaining < 5 &&

--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -421,7 +421,11 @@ class ListingsDetail extends Component {
                 )}
               </div>
               <h1 className="title text-truncate placehold">{name}</h1>
-              <p className="description placehold">{description}</p>
+              <p className="description placehold">
+                {description && description.split('\n').map((item, key) => {
+                  return <Fragment key={key}>{item}<br/></Fragment>
+                })}
+              </p>
               {/* Via Stan 5/25/2018: Hide until contracts allow for unitsRemaining > 1 */}
               {/*!!unitsRemaining && unitsRemaining < 5 &&
                 <div className="units-remaining text-danger">

--- a/src/components/listing-detail.js
+++ b/src/components/listing-detail.js
@@ -268,7 +268,8 @@ class ListingsDetail extends Component {
     const isAvailable = !isPending && !isSold
     const userIsBuyer = currentOffer && web3Account === currentOffer.buyer
     const userIsSeller = web3Account === seller
-    const showFeaturedBadge = !isSold && !isPending && featured.includes(this.props.listingId)
+    const showFeaturedBadge =
+      !isSold && !isPending && featured.includes(this.props.listingId)
 
     return (
       <div className="listing-detail">
@@ -422,9 +423,15 @@ class ListingsDetail extends Component {
               </div>
               <h1 className="title text-truncate placehold">{name}</h1>
               <p className="description placehold">
-                {description && description.split('\n').map((item, key) => {
-                  return <Fragment key={key}>{item}<br/></Fragment>
-                })}
+                {description &&
+                  description.split('\n').map((item, key) => {
+                    return (
+                      <Fragment key={key}>
+                        {item}
+                        <br />
+                      </Fragment>
+                    )
+                  })}
               </p>
               {/* Via Stan 5/25/2018: Hide until contracts allow for unitsRemaining > 1 */}
               {/*!!unitsRemaining && unitsRemaining < 5 &&

--- a/src/components/purchase-detail.js
+++ b/src/components/purchase-detail.js
@@ -1113,7 +1113,7 @@ class PurchaseDetail extends Component {
                     <h1 className="title text-truncate placehold">
                       {listing.name}
                     </h1>
-                    <p className="description placehold">
+                    <p className="ws-aware description placehold">
                       {listing.description}
                     </p>
                     {/*!!listing.unitsRemaining && listing.unitsRemaining < 5 &&

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -124,6 +124,10 @@ textarea:-moz-ui-invalid {
   color: var(--dark-two);
 }
 
+.ws-aware {
+  white-space: pre-line;
+}
+
 .table {
   font-size: 0.875rem;
   margin-bottom: 0;

--- a/src/pages/profile/Profile.js
+++ b/src/pages/profile/Profile.js
@@ -309,7 +309,7 @@ class Profile extends Component {
                       </button>
                     </div>
                   </div>
-                  <p>{description}</p>
+                  <p className="ws-aware">{description}</p>
                 </div>
               </div>
 

--- a/src/pages/user/User.js
+++ b/src/pages/user/User.js
@@ -71,7 +71,7 @@ class User extends Component {
               <div className="name d-flex">
                 <h1>{fullName || <UnnamedUser />}</h1>
               </div>
-              <p>{description}</p>
+              <p className="ws-aware">{description}</p>
             </div>
             <div className="col-12 col-sm-4 col-md-3 col-lg-2 order-md-4">
               {attestations &&


### PR DESCRIPTION
per request from @joshfraser, following code from here:
https://medium.com/@kevinsimper/react-newline-to-break-nl2br-a1c240ba746

Newlines get converted to <br> tags, nothing more. 

We might consider supporting full-on markdown (eg [via this package](https://www.npmjs.com/package/react-markdown)) , but we'd want to disable images, and have a bigger discussion of whether markdown is the officially recommended format for Origin listings.

