### PR TITLE
Update DApp to use origin 0.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14533,9 +14533,9 @@
       }
     },
     "origin": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/origin/-/origin-0.8.2.tgz",
-      "integrity": "sha512-/KUPmsg5kXI545iY/WNY+cwBLqKkBKYMcx6gz3V0h/pcTARumLgL+i2GE7z1Xe2LTHQgXeryJWQvzirgU2843w==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/origin/-/origin-0.8.3.tgz",
+      "integrity": "sha512-o6gk3AitYpwpIc8qC5EEU+o6/63zKvXVGpkzcxVURFBmfzKmLv3NyGc65Tnz+HlMN/o2EwY5Xt5OyICpbWfiwA==",
       "requires": {
         "ajv": "6.5.2",
         "babel-polyfill": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mini-css-extract-plugin": "^0.4.3",
     "moment": "^2.22.1",
     "orbit-db": "^0.19.8",
-    "origin": "^0.8.2",
+    "origin": "^0.8.3",
     "popper.js": "^1.14.3",
     "query-string": "6.1.0",
     "rc-slider": "8.6.1",


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)

### Description:
Upgrade to using origin npm 0.8.3
