### PR TITLE
Dropdown Behavior Improvements

### DIFF
--- a/src/components/dropdowns/connectivity.js
+++ b/src/components/dropdowns/connectivity.js
@@ -67,8 +67,16 @@ class ConnectivityDropdown extends Component {
   }
 
   async componentDidMount() {
-    $(document).on('click', '.connectivity .dropdown-menu', e => {
-      e.stopPropagation()
+    // control hiding of dropdown menu
+    $('.connectivity.dropdown').on('hide.bs.dropdown', function({ clickEvent }) {
+      // if triggered by data-toggle
+      if (!clickEvent) {
+        return true
+      }
+      // otherwise only if triggered by self or another dropdown
+      const el = $(clickEvent.target)
+
+      return el.hasClass('dropdown') && el.hasClass('nav-item')
     })
 
     !web3.givenProvider &&

--- a/src/components/dropdowns/messages.js
+++ b/src/components/dropdowns/messages.js
@@ -154,9 +154,11 @@ class MessagesDropdown extends Component {
                   key={c.key}
                   conversation={c}
                   active={false}
-                  handleConversationSelect={() =>
+                  handleConversationSelect={() => {
                     history.push(`/messages/${c.key}`)
-                  }
+
+                    $('#messagesDropdown').dropdown('toggle')
+                  }}
                 />
               ))}
             </div>

--- a/src/components/dropdowns/messages.js
+++ b/src/components/dropdowns/messages.js
@@ -33,11 +33,19 @@ class MessagesDropdown extends Component {
   }
 
   componentDidMount() {
-    $(document).on('click', '.messages .dropdown-menu', e => {
-      e.stopPropagation()
+    // control hiding of dropdown menu
+    $('.messages.dropdown').on('hide.bs.dropdown', function({ clickEvent }) {
+      // if triggered by data-toggle
+      if (!clickEvent) {
+        return true
+      }
+      // otherwise only if triggered by self or another dropdown
+      const el = $(clickEvent.target)
+
+      return el.hasClass('dropdown') && el.hasClass('nav-item')
     })
 
-    $('.messages.dropdown').on('hide.bs.dropdown', this.props.dismissMessaging)
+    $('.messages.dropdown').on('hidden.bs.dropdown', this.props.dismissMessaging)
   }
 
   componentDidUpdate() {

--- a/src/components/dropdowns/notifications.js
+++ b/src/components/dropdowns/notifications.js
@@ -17,8 +17,16 @@ class NotificationsDropdown extends Component {
   }
 
   componentDidMount() {
-    $(document).on('click', '.notifications .dropdown-menu', e => {
-      e.stopPropagation()
+    // control hiding of dropdown menu
+    $('.notifications.dropdown').on('hide.bs.dropdown', function({ clickEvent }) {
+      // if triggered by data-toggle
+      if (!clickEvent) {
+        return true
+      }
+      // otherwise only if triggered by self or another dropdown
+      const el = $(clickEvent.target)
+
+      return el.hasClass('dropdown') && el.hasClass('nav-item')
     })
 
     $('.notifications.dropdown').on('hide.bs.dropdown', () => {

--- a/src/components/dropdowns/transactions.js
+++ b/src/components/dropdowns/transactions.js
@@ -19,8 +19,16 @@ class TransactionsDropdown extends Component {
   }
 
   componentDidMount() {
-    $(document).on('click', '.transactions .dropdown-menu', e => {
-      e.stopPropagation()
+    // control hiding of dropdown menu
+    $('.transactions.dropdown').on('hide.bs.dropdown', function({ clickEvent }) {
+      // if triggered by data-toggle
+      if (!clickEvent) {
+        return true
+      }
+      // otherwise only if triggered by self or another dropdown
+      const el = $(clickEvent.target)
+
+      return el.hasClass('dropdown') && el.hasClass('nav-item')
     })
   }
 

--- a/src/components/dropdowns/user.js
+++ b/src/components/dropdowns/user.js
@@ -8,13 +8,17 @@ import Identicon from 'components/identicon'
 import WalletCard from 'components/wallet-card'
 
 class UserDropdown extends Component {
-  constructor(props) {
-    super(props)
-  }
-
   componentDidMount() {
-    $(document).on('click', '.identity .dropdown-menu', e => {
-      e.stopPropagation()
+    // control hiding of dropdown menu
+    $('.identity.dropdown').on('hide.bs.dropdown', function({ clickEvent }) {
+      // if triggered by data-toggle
+      if (!clickEvent) {
+        return true
+      }
+      // otherwise only if triggered by self or another dropdown
+      const el = $(clickEvent.target)
+
+      return el.hasClass('dropdown') && el.hasClass('nav-item')
     })
   }
 

--- a/src/components/dropdowns/user.js
+++ b/src/components/dropdowns/user.js
@@ -22,6 +22,10 @@ class UserDropdown extends Component {
     })
   }
 
+  handleClick() {
+    $('#identityDropdown').dropdown('toggle')
+  }
+
   render() {
     const { wallet } = this.props
 
@@ -48,7 +52,7 @@ class UserDropdown extends Component {
           </div>
           <div className="actual-menu">
             <WalletCard wallet={wallet} withMenus={false} withProfile={true} />
-            <Link to="/profile" className="btn edit-profile placehold">
+            <Link to="/profile" className="btn edit-profile placehold" onClick={this.handleClick}>
               <FormattedMessage
                 id={'user-dropdown.EditProfile'}
                 defaultMessage={'Edit Profile'}

--- a/src/components/notification.js
+++ b/src/components/notification.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
+import $ from 'jquery'
 
 import { updateNotification } from 'actions/Notification'
 import { fetchUser } from 'actions/User'
@@ -45,6 +46,8 @@ class Notification extends Component {
 
   handleClick() {
     this.props.updateNotification(this.props.notification.id, 'read')
+
+    $('#notificationsDropdown').dropdown('toggle')
   }
 
   render() {

--- a/src/pages/profile/Profile.js
+++ b/src/pages/profile/Profile.js
@@ -130,6 +130,10 @@ class Profile extends Component {
       provisional: this.props.provisionalProgress,
       published: this.props.publishedProgress
     })
+
+    if ($('.identity.dropdown').hasClass('show')) {
+      $('#identityDropdown').dropdown('toggle')
+    }
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~Wrap any new text/strings for translation~
- [ ] ~Map any new environment variables with a default value in the Webpack config~
- [ ] ~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)~

### Description:

The default behavior for a Bootstrap dropdown is for it to hide on any click (inside or outside of the menu). I had previously disabled this in some cases but it was inconsistent.

With these changes, the default behavior is for a dropdown to only hide if the nav icon (or its parent) is clicked. Other various clicks will no longer affect the dropdown(s). Manual "toggle" calls are now fired selectively where appropriate. This will be an ongoing effort.

This is one of several things that should be more thoughtfully engineered as a part of a broader effort to remove jQuery and implement our own vanilla components.