### PR TITLE
Price filter query fix

### DIFF
--- a/src/components/search/price-filter.js
+++ b/src/components/search/price-filter.js
@@ -41,13 +41,13 @@ class PriceFilter extends Component {
     return [
       {
         name: this.props.filter.searchParameterName,
-        value: getCryptoPrice(this.state.value[0], 'USD', 'ETH'),
+        value: await getCryptoPrice(this.state.value[0], 'USD', 'ETH'),
         valueType: VALUE_TYPE_FLOAT,
         operator: FILTER_OPERATOR_GREATER_OR_EQUAL
       },
       {
         name: this.props.filter.searchParameterName,
-        value: getCryptoPrice(this.state.value[1], 'USD', 'ETH'),
+        value: await getCryptoPrice(this.state.value[1], 'USD', 'ETH'),
         valueType: VALUE_TYPE_FLOAT,
         operator: FILTER_OPERATOR_LESSER_OR_EQUAL
       }


### PR DESCRIPTION
### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything

### Description:
Solves the problem where search fails when using price filter. 

The problem was [this Pull Request](https://github.com/OriginProtocol/origin-dapp/pull/604/files#diff-272e0265387bbb386b63efe467f8450fL43) the whole bug is probably a result of bad master merge. 

Solves issue: https://github.com/OriginProtocol/origin-js/issues/595

